### PR TITLE
Add SlackCredential model and migration

### DIFF
--- a/app/models/slack_credential.rb
+++ b/app/models/slack_credential.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# rbs_inline: enabled
+
+# Slack OAuth 인증 정보를 저장하는 모델
+class SlackCredential < ApplicationRecord
+  belongs_to :user
+
+  encrypts :access_token
+  encrypts :refresh_token, deterministic: false
+
+  validates :access_token, presence: { message: "액세스 토큰을 입력해주세요" }
+  validates :team_id, presence: { message: "팀 ID를 입력해주세요" }
+  validates :team_name, presence: { message: "팀 이름을 입력해주세요" }
+
+  # 토큰 만료 확인
+  def expired? #: () -> bool
+    return false if expires_at.nil?
+
+    expires_at < Time.current
+  end
+
+  # 토큰 갱신 필요 여부 (만료 1시간 전)
+  def needs_refresh? #: () -> bool
+    return false if expires_at.nil?
+
+    expires_at < 1.hour.from_now
+  end
+
+  # 유효한 액세스 토큰 가져오기 (필요시 자동 갱신)
+  def valid_access_token #: () -> String?
+    return access_token unless needs_refresh?
+    return access_token if refresh_token.blank?
+
+    refresh_access_token
+    access_token
+  end
+
+  private
+
+  def refresh_access_token #: () -> void
+    oauth_config = Preference.get_object("slack_oauth")
+    client = OauthClientService.call(oauth_config)
+
+    new_token = client.auth_code.get_token(
+      refresh_token,
+      grant_type: "refresh_token"
+    )
+
+    update!(
+      access_token: new_token.token,
+      refresh_token: new_token.refresh_token || refresh_token,
+      expires_at: new_token.expires_at ? Time.at(new_token.expires_at) : nil,
+      token_created_at: Time.current
+    )
+  rescue OAuth2::Error => e
+    Rails.logger.error("Slack token refresh failed: #{e.message}")
+    nil
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@
 class User < ApplicationRecord
   has_secure_password
   has_many :sessions, dependent: :destroy
+  has_many :slack_credentials, dependent: :destroy
 
   # Email validations
   validates :email_address, presence: true,

--- a/db/migrate/20251008121000_create_slack_credentials.rb
+++ b/db/migrate/20251008121000_create_slack_credentials.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class CreateSlackCredentials < ActiveRecord::Migration[8.0]
+  def change
+    create_table :slack_credentials do |t|
+      t.references :user, null: false, foreign_key: true, comment: "사용자 ID"
+
+      # Slack OAuth 토큰 정보 (암호화됨)
+      t.text :access_token, null: false, comment: "액세스 토큰 (암호화)"
+      t.text :refresh_token, comment: "리프레시 토큰 (암호화)"
+
+      # 토큰 메타데이터
+      t.datetime :expires_at, comment: "토큰 만료 시각"
+      t.datetime :token_created_at, null: false, comment: "토큰 발급 시각"
+
+      # Slack 팀 정보
+      t.string :team_id, null: false, comment: "Slack 팀 ID"
+      t.string :team_name, null: false, comment: "Slack 팀 이름"
+
+      # 추가 메타데이터
+      t.string :scope, comment: "승인된 권한 범위"
+      t.string :bot_user_id, comment: "봇 사용자 ID"
+      t.string :webhook_url, comment: "Incoming Webhook URL"
+      t.string :webhook_channel, comment: "Webhook 채널명"
+
+      t.timestamps
+
+      # 인덱스
+      t.index [ :user_id, :team_id ], unique: true, name: "index_slack_credentials_on_user_and_team"
+      t.index :team_id, name: "index_slack_credentials_on_team_id"
+      t.index :expires_at, name: "index_slack_credentials_on_expires_at"
+    end
+  end
+end

--- a/test/fixtures/slack_credentials.yml
+++ b/test/fixtures/slack_credentials.yml
@@ -1,0 +1,24 @@
+# Slack OAuth 인증 정보 픽스처
+
+john_workspace:
+  user: john
+  access_token: xoxb-test-token-john
+  refresh_token: xoxe-test-refresh-john
+  expires_at: <%= 2.hours.from_now %>
+  token_created_at: <%= Time.current %>
+  team_id: T123456
+  team_name: John's Workspace
+  scope: chat:write,incoming-webhook
+  bot_user_id: U123456
+  webhook_url: https://hooks.slack.com/services/T123/B456/xyz
+  webhook_channel: general
+
+admin_workspace:
+  user: admin
+  access_token: xoxb-test-token-admin
+  refresh_token: xoxe-test-refresh-admin
+  expires_at: <%= 30.minutes.from_now %>
+  token_created_at: <%= Time.current %>
+  team_id: T789012
+  team_name: Admin's Workspace
+  scope: chat:write

--- a/test/models/slack_credential_test.rb
+++ b/test/models/slack_credential_test.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SlackCredentialTest < ActiveSupport::TestCase
+  def setup
+    @user = users(:john)
+    @credential = SlackCredential.new(
+      user: @user,
+      access_token: "xoxb-test-token",
+      refresh_token: "xoxe-test-refresh",
+      expires_at: 1.hour.from_now,
+      token_created_at: Time.current,
+      team_id: "T123456",
+      team_name: "Test Team"
+    )
+  end
+
+  # ========== Validation Tests ==========
+
+  test "유효한 속성을 가진 경우 유효해야 한다" do
+    assert @credential.valid?
+  end
+
+  test "access_token은 필수 항목이어야 한다" do
+    @credential.access_token = nil
+    assert_not @credential.valid?
+    assert_includes @credential.errors[:access_token], "액세스 토큰을 입력해주세요"
+  end
+
+  test "team_id는 필수 항목이어야 한다" do
+    @credential.team_id = nil
+    assert_not @credential.valid?
+    assert_includes @credential.errors[:team_id], "팀 ID를 입력해주세요"
+  end
+
+  test "team_name은 필수 항목이어야 한다" do
+    @credential.team_name = nil
+    assert_not @credential.valid?
+    assert_includes @credential.errors[:team_name], "팀 이름을 입력해주세요"
+  end
+
+  # ========== Association Tests ==========
+
+  test "user와 연관되어야 한다" do
+    assert_respond_to @credential, :user
+    assert_equal @user, @credential.user
+  end
+
+  test "user가 삭제되면 함께 삭제되어야 한다" do
+    @credential.save!
+    assert_difference "SlackCredential.count", -1 do
+      @user.destroy
+    end
+  end
+
+  # ========== Token Expiration Tests ==========
+
+  test "expired? - 만료되지 않은 토큰" do
+    @credential.expires_at = 1.hour.from_now
+    assert_not @credential.expired?
+  end
+
+  test "expired? - 만료된 토큰" do
+    @credential.expires_at = 1.hour.ago
+    assert @credential.expired?
+  end
+
+  test "expired? - expires_at이 nil인 경우" do
+    @credential.expires_at = nil
+    assert_not @credential.expired?
+  end
+
+  test "needs_refresh? - 갱신이 필요한 토큰 (1시간 이내 만료)" do
+    @credential.expires_at = 30.minutes.from_now
+    assert @credential.needs_refresh?
+  end
+
+  test "needs_refresh? - 갱신이 필요하지 않은 토큰" do
+    @credential.expires_at = 2.hours.from_now
+    assert_not @credential.needs_refresh?
+  end
+
+  test "needs_refresh? - expires_at이 nil인 경우" do
+    @credential.expires_at = nil
+    assert_not @credential.needs_refresh?
+  end
+
+  # ========== Encryption Tests ==========
+
+  test "access_token은 암호화되어 저장되어야 한다" do
+    @credential.save!
+
+    # 데이터베이스에서 직접 읽은 값은 암호화되어 있어야 함
+    raw_value = ActiveRecord::Base.connection.execute(
+      "SELECT access_token FROM slack_credentials WHERE id = #{@credential.id}"
+    ).first["access_token"]
+
+    assert_not_equal "xoxb-test-token", raw_value
+
+    # 모델을 통해 읽으면 복호화된 값을 반환
+    assert_equal "xoxb-test-token", @credential.reload.access_token
+  end
+
+  test "refresh_token은 암호화되어 저장되어야 한다" do
+    @credential.save!
+
+    raw_value = ActiveRecord::Base.connection.execute(
+      "SELECT refresh_token FROM slack_credentials WHERE id = #{@credential.id}"
+    ).first["refresh_token"]
+
+    assert_not_equal "xoxe-test-refresh", raw_value
+    assert_equal "xoxe-test-refresh", @credential.reload.refresh_token
+  end
+
+  # ========== Uniqueness Tests ==========
+
+  test "같은 user와 team_id 조합은 유일해야 한다" do
+    @credential.save!
+
+    duplicate = SlackCredential.new(
+      user: @user,
+      access_token: "xoxb-another-token",
+      team_id: "T123456",
+      team_name: "Test Team"
+    )
+
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      duplicate.save(validate: false)
+    end
+  end
+
+  test "다른 team_id는 같은 user에게 허용되어야 한다" do
+    @credential.save!
+
+    another_team = SlackCredential.new(
+      user: @user,
+      access_token: "xoxb-another-token",
+      team_id: "T789012",
+      team_name: "Another Team"
+    )
+
+    assert another_team.valid?
+    assert_difference "SlackCredential.count", 1 do
+      another_team.save!
+    end
+  end
+end


### PR DESCRIPTION
Implement encrypted Slack OAuth tokens with refresh logic and uniqueness on user/team. Add association in User, migration with indexes, fixtures and model tests validating expiration, refresh behavior, encryption.