### PR TITLE
Add GraphQL article feed endpoint for iOS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "stimulus-rails"
 gem "tailwindcss-rails", "~> 4.2"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
+gem "graphql", "~> 2.5"
 
 # Authentication [https://github.com/heartcombo/devise]
 gem "devise", "~> 5.0"

--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,8 @@ gem "stimulus-rails"
 # Use Tailwind CSS [https://github.com/rails/tailwindcss-rails]
 gem "tailwindcss-rails", "~> 4.2"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
-gem "jbuilder"
 gem "graphql", "~> 2.5"
+gem "jbuilder"
 
 # Authentication [https://github.com/heartcombo/devise]
 gem "devise", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,7 @@ GEM
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
+    fiber-storage (1.0.1)
     flog (4.9.4)
       path_expander (~> 2.0)
       prism (~> 1.7)
@@ -244,6 +245,10 @@ GEM
     google-protobuf (4.35.0-x86_64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
+    graphql (2.6.2)
+      base64
+      fiber-storage
+      logger
     guess_html_encoding (0.0.11)
     hairtrigger (1.3.1)
       activerecord (>= 6.0, < 9)
@@ -827,6 +832,7 @@ DEPENDENCIES
   flog
   friendly_id
   google-protobuf
+  graphql (~> 2.5)
   hairtrigger
   honeybadger
   image_processing (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,7 +431,7 @@ GEM
     openssl (4.0.2)
     orm_adapter (0.5.0)
     ostruct (0.6.3)
-    pagy (43.5.4)
+    pagy (43.5.5)
       json
       uri
       yaml
@@ -697,7 +697,7 @@ GEM
       version_gem (>= 1.1.8, < 3)
     socialization (3.0.0)
       activerecord (>= 6.1)
-    solid_cable (3.0.12)
+    solid_cable (4.0.0)
       actioncable (>= 7.2)
       activejob (>= 7.2)
       activerecord (>= 7.2)

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class GraphqlController < ApplicationController
+  skip_before_action :verify_authenticity_token, raise: false
+  skip_before_action :authenticate_user!
+  before_action :authenticate_user_from_bearer_token
+
+  def execute
+    result = AlNewsSchema.execute(
+      params[:query],
+      variables: variables,
+      context: { current_user: current_user }
+    )
+
+    render json: result
+  end
+
+  private
+    def authenticate_user_from_bearer_token
+      return if request.authorization.blank?
+
+      authenticate_user!
+    end
+
+    def variables
+      case params[:variables]
+      when String
+        params[:variables].present? ? JSON.parse(params[:variables]) : {}
+      when Hash, ActionController::Parameters
+        params[:variables]
+      when nil
+        {}
+      else
+        raise ArgumentError, "Unexpected parameter: variables"
+      end
+    end
+end

--- a/app/graphql/al_news_schema.rb
+++ b/app/graphql/al_news_schema.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AlNewsSchema < GraphQL::Schema
+  query Types::QueryType
+end

--- a/app/graphql/resolvers/article_feed_resolver.rb
+++ b/app/graphql/resolvers/article_feed_resolver.rb
@@ -3,7 +3,7 @@
 
 module Resolvers
   class ArticleFeedResolver < GraphQL::Schema::Resolver
-    type Types::ArticleFeedType, null: true
+    type Types::ArticleFeedType, null: false
 
     argument :kind, Types::ArticleFeedKindEnum, required: true
     argument :search, String, required: false

--- a/app/graphql/resolvers/article_feed_resolver.rb
+++ b/app/graphql/resolvers/article_feed_resolver.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+module Resolvers
+  class ArticleFeedResolver < GraphQL::Schema::Resolver
+    type Types::ArticleFeedType, null: true
+
+    argument :kind, Types::ArticleFeedKindEnum, required: true
+    argument :search, String, required: false
+    argument :keyword, String, required: false
+    argument :page, String, required: false
+    argument :limit, Integer, required: false
+
+    #: (kind: String, ?search: String?, ?keyword: String?, ?page: String?, ?limit: Integer?) -> Hash[Symbol, untyped]
+    def resolve(kind:, search: nil, keyword: nil, page: nil, limit: nil)
+      relation = article_relation(kind:, search:, keyword:)
+      pagy = Pagy::Keyset.new(
+        relation.reorder(published_at: :desc, id: :desc),
+        page:,
+        limit: limit || Pagy::OPTIONS[:limit]
+      )
+      articles = pagy.records
+      context[:liked_article_ids] = liked_article_ids(articles)
+
+      {
+        articles:,
+        pagination: {
+          page: pagy.page,
+          next_page: pagy.next,
+          limit: pagy.limit
+        }
+      }
+    end
+
+    private
+      #: (kind: String, search: String?, keyword: String?) -> ActiveRecord::Relation
+      def article_relation(kind:, search:, keyword:)
+        case kind
+        when "RELATED"
+          Articles::Query.index_json(search)
+        when "OTHERS"
+          Articles::Query.others
+        when "TAGGED"
+          raise GraphQL::ExecutionError, "keyword is required for tagged article feed" if keyword.blank?
+
+          Articles::Query.tagged(keyword)
+        else
+          raise GraphQL::ExecutionError, "unsupported article feed kind"
+        end
+      end
+
+      #: (Array[Article]) -> Array[Integer]
+      def liked_article_ids(articles)
+        Like.liked_ids_for(
+          liker: context[:current_user],
+          likeable_type: "Article",
+          likeable_ids: articles.map(&:id)
+        )
+      end
+  end
+end

--- a/app/graphql/types/article_feed_kind_enum.rb
+++ b/app/graphql/types/article_feed_kind_enum.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  class ArticleFeedKindEnum < Types::BaseEnum
+    graphql_name "ArticleFeedKind"
+
+    value "RELATED", "Related articles feed"
+    value "OTHERS", "Other articles feed"
+    value "TAGGED", "Articles tagged with a keyword"
+  end
+end

--- a/app/graphql/types/article_feed_type.rb
+++ b/app/graphql/types/article_feed_type.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Types
+  class ArticleFeedType < Types::BaseObject
+    field :articles, [Types::ArticleType], null: false
+    field :pagination, Types::PaginationType, null: false
+  end
+end

--- a/app/graphql/types/article_feed_type.rb
+++ b/app/graphql/types/article_feed_type.rb
@@ -2,7 +2,7 @@
 
 module Types
   class ArticleFeedType < Types::BaseObject
-    field :articles, [Types::ArticleType], null: false
+    field :articles, [ Types::ArticleType ], null: false
     field :pagination, Types::PaginationType, null: false
   end
 end

--- a/app/graphql/types/article_type.rb
+++ b/app/graphql/types/article_type.rb
@@ -11,7 +11,7 @@ module Types
     field :likers_count, Integer, null: false
     field :posts_count, Integer, null: false
     field :summary_key, GraphQL::Types::JSON, null: true
-    field :tags, [String], null: false
+    field :tags, [ String ], null: false
     field :liked, Boolean, null: false
     field :published_at, GraphQL::Types::ISO8601DateTime, null: true
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/graphql/types/article_type.rb
+++ b/app/graphql/types/article_type.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Types
+  class ArticleType < Types::BaseObject
+    field :slug, String, null: true
+    field :title, String, null: true
+    field :title_ko, String, null: true
+    field :url, String, null: true
+    field :host, String, null: true
+    field :is_related, Boolean, null: false
+    field :likers_count, Integer, null: false
+    field :posts_count, Integer, null: false
+    field :summary_key, GraphQL::Types::JSON, null: true
+    field :tags, [String], null: false
+    field :liked, Boolean, null: false
+    field :published_at, GraphQL::Types::ISO8601DateTime, null: true
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+    def tags
+      object.tags.map(&:name)
+    end
+
+    def liked
+      context[:liked_article_ids]&.include?(object.id) || false
+    end
+  end
+end

--- a/app/graphql/types/base_enum.rb
+++ b/app/graphql/types/base_enum.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Types
+  class BaseEnum < GraphQL::Schema::Enum
+  end
+end

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Types
+  class BaseObject < GraphQL::Schema::Object
+  end
+end

--- a/app/graphql/types/pagination_type.rb
+++ b/app/graphql/types/pagination_type.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Types
+  class PaginationType < Types::BaseObject
+    field :page, String, null: true
+    field :next_page, String, null: true
+    field :limit, Integer, null: false
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -3,5 +3,7 @@
 module Types
   class QueryType < Types::BaseObject
     description "The query root of this schema"
+
+    field :article_feed, resolver: Resolvers::ArticleFeedResolver
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Types
+  class QueryType < Types::BaseObject
+    description "The query root of this schema"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,8 @@ Rails.application.routes.draw do
     post "account/oauth-signup", to: "users/oauth_registrations#create", as: :user_oauth_registration
   end
 
+  post "/graphql", to: "graphql#execute"
+
   namespace :api do
     namespace :v1 do
       namespace :auth do

--- a/docs/superpowers/plans/2026-05-25-ios-graphql-article-feed.md
+++ b/docs/superpowers/plans/2026-05-25-ios-graphql-article-feed.md
@@ -1,0 +1,650 @@
+# iOS GraphQL Article Feed Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a small GraphQL article feed API that lets the iOS app replace the existing article list REST calls without removing those REST endpoints yet.
+
+**Architecture:** Add `graphql-ruby`, expose `POST /graphql`, and implement a single `articleFeed` query. The resolver delegates feed selection to the existing `Articles::Query` module and keeps the current Pagy keyset pagination and optional liked personalization.
+
+**Tech Stack:** Rails 8.1, Ruby 4.0, graphql-ruby, Devise/JWT, Pagy keyset, Minitest, PostgreSQL.
+
+---
+
+## File Structure
+
+- Modify `Gemfile`: add the `graphql` gem near the existing API/JSON gems.
+- Modify `config/routes.rb`: add `post "/graphql", to: "graphql#execute"`.
+- Create `app/controllers/graphql_controller.rb`: JSON-only GraphQL endpoint with optional bearer-token authentication.
+- Create `app/graphql/al_news_schema.rb`: root GraphQL schema.
+- Create `app/graphql/types/base_object.rb`: shared GraphQL object base class.
+- Create `app/graphql/types/base_enum.rb`: shared GraphQL enum base class.
+- Create `app/graphql/types/query_type.rb`: root query field registration.
+- Create `app/graphql/types/article_feed_kind_enum.rb`: feed-kind enum.
+- Create `app/graphql/types/article_type.rb`: article fields matching the iOS REST contract.
+- Create `app/graphql/types/article_feed_type.rb`: feed payload wrapper.
+- Create `app/graphql/types/pagination_type.rb`: pagination payload wrapper.
+- Create `app/graphql/resolvers/article_feed_resolver.rb`: resolver that applies `Articles::Query`, Pagy keyset, and liked-id calculation.
+- Create `test/controllers/graphql_controller_test.rb`: request tests for public, tagged, authenticated-liked, and invalid tagged feed behavior.
+
+Do not edit `Api::V1::ArticlesController` in this pass. REST endpoints stay available.
+
+---
+
+### Task 1: Add GraphQL Dependency
+
+**Files:**
+- Modify: `Gemfile`
+- Modify: `Gemfile.lock`
+
+- [ ] **Step 1: Add the gem**
+
+Add this line immediately after `gem "jbuilder"` in `Gemfile`:
+
+```ruby
+gem "graphql", "~> 2.5"
+```
+
+- [ ] **Step 2: Install dependencies**
+
+Run:
+
+```bash
+bundle install
+```
+
+Expected: Bundler resolves and writes `Gemfile.lock` with `graphql`.
+
+- [ ] **Step 3: Verify the gem is installed**
+
+Run:
+
+```bash
+bundle exec ruby -e 'require "graphql"; puts GraphQL::VERSION'
+```
+
+Expected: prints a `2.5.x` or newer compatible `2.x` version.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add Gemfile Gemfile.lock
+git commit -m "Add GraphQL dependency"
+```
+
+---
+
+### Task 2: Write Failing GraphQL Request Tests
+
+**Files:**
+- Create: `test/controllers/graphql_controller_test.rb`
+
+- [ ] **Step 1: Create the failing tests**
+
+Create `test/controllers/graphql_controller_test.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GraphqlControllerTest < ActionDispatch::IntegrationTest
+  ARTICLE_FEED_QUERY = <<~GRAPHQL
+    query ArticleFeed($kind: ArticleFeedKind!, $search: String, $keyword: String, $page: String, $limit: Int) {
+      articleFeed(kind: $kind, search: $search, keyword: $keyword, page: $page, limit: $limit) {
+        articles {
+          slug
+          title
+          titleKo
+          url
+          host
+          isRelated
+          likersCount
+          postsCount
+          summaryKey
+          tags
+          liked
+          publishedAt
+          createdAt
+          updatedAt
+        }
+        pagination {
+          page
+          nextPage
+          limit
+        }
+      }
+    }
+  GRAPHQL
+
+  test "public related feed returns articles and pagination" do
+    post graphql_path,
+         params: { query: ARTICLE_FEED_QUERY, variables: { kind: "RELATED" } },
+         as: :json
+
+    assert_response :success
+    body = JSON.parse(response.body)
+
+    assert_nil body["errors"]
+    assert_kind_of Array, body.dig("data", "articleFeed", "articles")
+    assert_kind_of Hash, body.dig("data", "articleFeed", "pagination")
+    assert_equal 15, body.dig("data", "articleFeed", "pagination", "limit")
+  end
+
+  test "public others feed returns articles" do
+    post graphql_path,
+         params: { query: ARTICLE_FEED_QUERY, variables: { kind: "OTHERS" } },
+         as: :json
+
+    assert_response :success
+    body = JSON.parse(response.body)
+
+    assert_nil body["errors"]
+    assert_kind_of Array, body.dig("data", "articleFeed", "articles")
+  end
+
+  test "public tagged feed filters by keyword" do
+    article = articles(:ruby_article)
+    make_visible_related_article(article)
+    article.tag_list.add("ruby")
+    article.save!
+
+    post graphql_path,
+         params: { query: ARTICLE_FEED_QUERY, variables: { kind: "TAGGED", keyword: "ruby" } },
+         as: :json
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    slugs = body.dig("data", "articleFeed", "articles").map { |item| item["slug"] }
+
+    assert_nil body["errors"]
+    assert_includes slugs, article.slug
+  end
+
+  test "authenticated related feed marks liked articles" do
+    user = users(:john)
+    article = articles(:ruby_article)
+    make_visible_related_article(article)
+    user.like!(article)
+    token = jwt_for(user)
+
+    post graphql_path,
+         params: { query: ARTICLE_FEED_QUERY, variables: { kind: "RELATED" } },
+         headers: { "Authorization" => token },
+         as: :json
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    liked_article = body.dig("data", "articleFeed", "articles").find { |item| item["slug"] == article.slug }
+
+    assert_nil body["errors"]
+    assert_equal true, liked_article["liked"]
+  end
+
+  test "tagged feed requires keyword" do
+    post graphql_path,
+         params: { query: ARTICLE_FEED_QUERY, variables: { kind: "TAGGED" } },
+         as: :json
+
+    assert_response :success
+    body = JSON.parse(response.body)
+
+    assert_nil body["data"]["articleFeed"]
+    assert_match "keyword is required for tagged article feed", body["errors"].first["message"]
+  end
+
+  private
+    def make_visible_related_article(article)
+      article.update!(
+        deleted_at: nil,
+        is_related: true,
+        title_ko: article.title_ko.presence || "루비 기사",
+        slug: article.slug.presence || "ruby-article",
+        published_at: article.published_at || Time.current
+      )
+    end
+
+    def jwt_for(user)
+      post user_session_path,
+           params: { user: { email: user.email, password: "password" } },
+           as: :json
+
+      response.headers.fetch("Authorization")
+    end
+end
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+TEST_DATABASE_URL=postgres://postgres:postgres1234@localhost:5432/ra-news_test bin/rails test test/controllers/graphql_controller_test.rb
+```
+
+Expected: fail because `graphql_path` or `GraphqlController` is not defined.
+
+- [ ] **Step 3: Commit the failing test**
+
+Run:
+
+```bash
+git add test/controllers/graphql_controller_test.rb
+git commit -m "Add GraphQL article feed request tests"
+```
+
+---
+
+### Task 3: Add Route, Controller, and Schema Skeleton
+
+**Files:**
+- Modify: `config/routes.rb`
+- Create: `app/controllers/graphql_controller.rb`
+- Create: `app/graphql/al_news_schema.rb`
+- Create: `app/graphql/types/base_object.rb`
+- Create: `app/graphql/types/base_enum.rb`
+- Create: `app/graphql/types/query_type.rb`
+
+- [ ] **Step 1: Add the route**
+
+In `config/routes.rb`, add this route after the Devise routes and before the `namespace :api` block:
+
+```ruby
+  post "/graphql", to: "graphql#execute"
+```
+
+- [ ] **Step 2: Add the controller**
+
+Create `app/controllers/graphql_controller.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+class GraphqlController < ApplicationController
+  skip_before_action :verify_authenticity_token, raise: false
+  skip_before_action :authenticate_user!
+  before_action :authenticate_user_from_bearer_token
+
+  def execute
+    result = AlNewsSchema.execute(
+      params[:query],
+      variables: variables,
+      context: { current_user: current_user }
+    )
+
+    render json: result
+  end
+
+  private
+    def authenticate_user_from_bearer_token
+      return if request.authorization.blank?
+
+      authenticate_user!
+    end
+
+    def variables
+      case params[:variables]
+      when String
+        params[:variables].present? ? JSON.parse(params[:variables]) : {}
+      when Hash, ActionController::Parameters
+        params[:variables]
+      when nil
+        {}
+      else
+        raise ArgumentError, "Unexpected parameter: variables"
+      end
+    end
+end
+```
+
+- [ ] **Step 3: Add GraphQL base types and schema**
+
+Create `app/graphql/types/base_object.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+module Types
+  class BaseObject < GraphQL::Schema::Object
+  end
+end
+```
+
+Create `app/graphql/types/base_enum.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+module Types
+  class BaseEnum < GraphQL::Schema::Enum
+  end
+end
+```
+
+Create `app/graphql/types/query_type.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+module Types
+  class QueryType < Types::BaseObject
+    description "The query root of this schema"
+  end
+end
+```
+
+Create `app/graphql/al_news_schema.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+class AlNewsSchema < GraphQL::Schema
+  query Types::QueryType
+end
+```
+
+- [ ] **Step 4: Run route and syntax validation**
+
+Run:
+
+```bash
+bin/rails routes -g graphql
+```
+
+Expected: output includes `POST /graphql(.:format) graphql#execute`.
+
+Run:
+
+```bash
+rails 'ai:tool[validate]' files=app/controllers/graphql_controller.rb,config/routes.rb level=rails
+```
+
+Expected: no syntax or Rails semantic errors.
+
+- [ ] **Step 5: Run the GraphQL tests**
+
+Run:
+
+```bash
+TEST_DATABASE_URL=postgres://postgres:postgres1234@localhost:5432/ra-news_test bin/rails test test/controllers/graphql_controller_test.rb
+```
+
+Expected: fail because `articleFeed` is not defined on `Types::QueryType`.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add config/routes.rb app/controllers/graphql_controller.rb app/graphql/al_news_schema.rb app/graphql/types/base_object.rb app/graphql/types/base_enum.rb app/graphql/types/query_type.rb
+git commit -m "Add GraphQL endpoint skeleton"
+```
+
+---
+
+### Task 4: Add Article Feed Types and Resolver
+
+**Files:**
+- Modify: `app/graphql/types/query_type.rb`
+- Create: `app/graphql/types/article_feed_kind_enum.rb`
+- Create: `app/graphql/types/article_type.rb`
+- Create: `app/graphql/types/article_feed_type.rb`
+- Create: `app/graphql/types/pagination_type.rb`
+- Create: `app/graphql/resolvers/article_feed_resolver.rb`
+
+- [ ] **Step 1: Add the enum and object types**
+
+Create `app/graphql/types/article_feed_kind_enum.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+module Types
+  class ArticleFeedKindEnum < Types::BaseEnum
+    value "RELATED", "Related articles feed"
+    value "OTHERS", "Other articles feed"
+    value "TAGGED", "Articles tagged with a keyword"
+  end
+end
+```
+
+Create `app/graphql/types/pagination_type.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+module Types
+  class PaginationType < Types::BaseObject
+    field :page, String, null: true
+    field :next_page, String, null: true
+    field :limit, Integer, null: false
+  end
+end
+```
+
+Create `app/graphql/types/article_type.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+module Types
+  class ArticleType < Types::BaseObject
+    field :slug, String, null: true
+    field :title, String, null: true
+    field :title_ko, String, null: true
+    field :url, String, null: true
+    field :host, String, null: true
+    field :is_related, Boolean, null: false
+    field :likers_count, Integer, null: false
+    field :posts_count, Integer, null: false
+    field :summary_key, GraphQL::Types::JSON, null: true
+    field :tags, [String], null: false
+    field :liked, Boolean, null: false
+    field :published_at, GraphQL::Types::ISO8601DateTime, null: true
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+    def tags
+      object.tags.map(&:name)
+    end
+
+    def liked
+      context[:liked_article_ids]&.include?(object.id) || false
+    end
+  end
+end
+```
+
+Create `app/graphql/types/article_feed_type.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+module Types
+  class ArticleFeedType < Types::BaseObject
+    field :articles, [Types::ArticleType], null: false
+    field :pagination, Types::PaginationType, null: false
+  end
+end
+```
+
+- [ ] **Step 2: Add the resolver**
+
+Create `app/graphql/resolvers/article_feed_resolver.rb`:
+
+```ruby
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+module Resolvers
+  class ArticleFeedResolver < GraphQL::Schema::Resolver
+    type Types::ArticleFeedType, null: false
+
+    argument :kind, Types::ArticleFeedKindEnum, required: true
+    argument :search, String, required: false
+    argument :keyword, String, required: false
+    argument :page, String, required: false
+    argument :limit, Integer, required: false
+
+    #: (kind: String, ?search: String?, ?keyword: String?, ?page: String?, ?limit: Integer?) -> Hash[Symbol, untyped]
+    def resolve(kind:, search: nil, keyword: nil, page: nil, limit: nil)
+      relation = article_relation(kind:, search:, keyword:)
+      pagy = Pagy::Keyset.new(
+        relation.reorder(published_at: :desc, id: :desc),
+        page:,
+        limit: limit || Pagy::OPTIONS[:limit]
+      )
+      articles = pagy.records
+      context[:liked_article_ids] = liked_article_ids(articles)
+
+      {
+        articles:,
+        pagination: {
+          page: pagy.page,
+          next_page: pagy.next,
+          limit: pagy.limit
+        }
+      }
+    end
+
+    private
+      #: (kind: String, search: String?, keyword: String?) -> ActiveRecord::Relation
+      def article_relation(kind:, search:, keyword:)
+        case kind
+        when "RELATED"
+          Articles::Query.index_json(search)
+        when "OTHERS"
+          Articles::Query.others
+        when "TAGGED"
+          raise GraphQL::ExecutionError, "keyword is required for tagged article feed" if keyword.blank?
+
+          Articles::Query.tagged(keyword)
+        else
+          raise GraphQL::ExecutionError, "unsupported article feed kind"
+        end
+      end
+
+      #: (Array[Article]) -> Array[Integer]
+      def liked_article_ids(articles)
+        Like.liked_ids_for(
+          liker: context[:current_user],
+          likeable_type: "Article",
+          likeable_ids: articles.map(&:id)
+        )
+      end
+  end
+end
+```
+
+- [ ] **Step 3: Register the field**
+
+Replace `app/graphql/types/query_type.rb` with:
+
+```ruby
+# frozen_string_literal: true
+
+module Types
+  class QueryType < Types::BaseObject
+    description "The query root of this schema"
+
+    field :article_feed, resolver: Resolvers::ArticleFeedResolver
+  end
+end
+```
+
+- [ ] **Step 4: Run focused validation and tests**
+
+Run:
+
+```bash
+rails 'ai:tool[validate]' files=app/graphql/types/query_type.rb,app/graphql/types/article_feed_kind_enum.rb,app/graphql/types/article_type.rb,app/graphql/types/article_feed_type.rb,app/graphql/types/pagination_type.rb,app/graphql/resolvers/article_feed_resolver.rb level=rails
+```
+
+Expected: no syntax or Rails semantic errors.
+
+Run:
+
+```bash
+TEST_DATABASE_URL=postgres://postgres:postgres1234@localhost:5432/ra-news_test bin/rails test test/controllers/graphql_controller_test.rb
+```
+
+Expected: all GraphQL controller tests pass.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add app/graphql/types/query_type.rb app/graphql/types/article_feed_kind_enum.rb app/graphql/types/article_type.rb app/graphql/types/article_feed_type.rb app/graphql/types/pagination_type.rb app/graphql/resolvers/article_feed_resolver.rb
+git commit -m "Add GraphQL article feed resolver"
+```
+
+---
+
+### Task 5: Final Verification and Graph Update
+
+**Files:**
+- Generated/updated: `graphify-out/`
+
+- [ ] **Step 1: Run existing REST API tests**
+
+Run:
+
+```bash
+TEST_DATABASE_URL=postgres://postgres:postgres1234@localhost:5432/ra-news_test bin/rails test test/controllers/api/v1/articles_controller_test.rb
+```
+
+Expected: pass. This confirms the existing REST article API was not broken.
+
+- [ ] **Step 2: Run GraphQL tests**
+
+Run:
+
+```bash
+TEST_DATABASE_URL=postgres://postgres:postgres1234@localhost:5432/ra-news_test bin/rails test test/controllers/graphql_controller_test.rb
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run quality gate**
+
+Run:
+
+```bash
+TEST_DATABASE_URL=postgres://postgres:postgres1234@localhost:5432/ra-news_test bin/rake quality
+```
+
+Expected: pass. Record line coverage, branch coverage, flog max method, and flog max class in the final response or PR description.
+
+- [ ] **Step 4: Rebuild graphify code graph**
+
+Run:
+
+```bash
+python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"
+```
+
+Expected: exits successfully and updates `graphify-out/` if code graph content changed.
+
+- [ ] **Step 5: Validate final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat HEAD
+```
+
+Expected: only GraphQL implementation, tests, lockfile, and graphify updates are present.
+
+- [ ] **Step 6: Commit final graph update if needed**
+
+Run:
+
+```bash
+git add graphify-out
+git commit -m "Update graph for GraphQL article feed"
+```
+
+If `graphify-out/` did not change, skip this commit.

--- a/docs/superpowers/specs/2026-05-25-ios-graphql-article-feed-design.md
+++ b/docs/superpowers/specs/2026-05-25-ios-graphql-article-feed-design.md
@@ -1,0 +1,186 @@
+# iOS GraphQL Article Feed Design
+
+## Goal
+
+Replace the iOS app's first set of article list REST calls with a GraphQL API while keeping the existing REST endpoints available during migration.
+
+The first implementation scope is intentionally small:
+
+- `GET /api/v1/articles`
+- `GET /api/v1/articles/others`
+- `GET /api/v1/articles/tag/:keyword`
+
+Authentication, token refresh, mutations, comments, likes, and article detail changes are out of scope for this first pass.
+
+## Current Behavior
+
+The existing REST article API is public. If a request includes a valid logged-in user, the response personalizes the `liked` field. If there is no current user, the endpoint still returns articles and `liked` resolves to `false`.
+
+All three REST actions use the same response shape:
+
+- `articles`: array of serialized articles
+- `pagination`: `page`, `next_page`, and `limit`
+
+The current article selection logic must remain the source of truth:
+
+- Main feed uses `Articles::Query.index_json(search)`
+- Other feed uses `Articles::Query.others`
+- Tagged feed uses `Articles::Query.tagged(keyword)`
+- All feeds order by `published_at desc, id desc`
+
+The GraphQL layer must reuse this query module instead of duplicating feed rules.
+
+## Chosen Approach
+
+Add a GraphQL endpoint with one feed query:
+
+```graphql
+query ArticleFeed(
+  $kind: ArticleFeedKind!,
+  $search: String,
+  $keyword: String,
+  $page: Int,
+  $limit: Int
+) {
+  articleFeed(kind: $kind, search: $search, keyword: $keyword, page: $page, limit: $limit) {
+    articles {
+      slug
+      title
+      titleKo
+      url
+      host
+      isRelated
+      likersCount
+      postsCount
+      summaryKey
+      tags
+      liked
+      publishedAt
+      createdAt
+      updatedAt
+    }
+    pagination {
+      page
+      nextPage
+      limit
+    }
+  }
+}
+```
+
+The enum values are:
+
+- `RELATED`: maps to the current `index` REST action
+- `OTHERS`: maps to the current `others` REST action
+- `TAGGED`: maps to the current `tag` REST action
+
+This keeps the iOS client on a single GraphQL operation while still preserving the three existing feed concepts.
+
+## Schema
+
+```graphql
+type Query {
+  articleFeed(
+    kind: ArticleFeedKind!,
+    search: String,
+    keyword: String,
+    page: Int,
+    limit: Int
+  ): ArticleFeed!
+}
+
+enum ArticleFeedKind {
+  RELATED
+  OTHERS
+  TAGGED
+}
+
+type ArticleFeed {
+  articles: [Article!]!
+  pagination: Pagination!
+}
+
+type Article {
+  slug: String
+  title: String
+  titleKo: String
+  url: String
+  host: String
+  isRelated: Boolean!
+  likersCount: Int!
+  postsCount: Int!
+  summaryKey: JSON
+  tags: [String!]!
+  liked: Boolean!
+  publishedAt: ISO8601DateTime
+  createdAt: ISO8601DateTime!
+  updatedAt: ISO8601DateTime!
+}
+
+type Pagination {
+  page: Int
+  nextPage: Int
+  limit: Int!
+}
+```
+
+## Authentication
+
+The first GraphQL endpoint must match current REST access:
+
+- Anonymous requests are allowed for `articleFeed`.
+- Requests with a bearer token should resolve `current_user` through the same Devise/JWT path used by existing API requests.
+- `Article.liked` should be `false` when no user is present.
+- `Article.liked` should be calculated from `Like.liked_ids_for` when a user is present.
+
+Token refresh stays on the existing REST endpoint for now.
+
+## Pagination
+
+Use the same Pagy keyset behavior as the REST controller. The GraphQL response should expose the existing pagination fields as camelCase:
+
+- `page`
+- `nextPage`
+- `limit`
+
+The first implementation does not introduce Relay connections. That can be revisited after the iOS app has moved its first article lists to GraphQL.
+
+## Error Handling
+
+Invalid input should produce GraphQL errors rather than REST-style JSON error objects.
+
+Rules:
+
+- `kind: TAGGED` requires `keyword`.
+- Blank `keyword` for `TAGGED` is invalid.
+- `search` is only meaningful for `RELATED`; ignore it for the other feed kinds unless the implementation can reject it without hurting client ergonomics.
+- Pagination values should use the same defaults as the current REST path when omitted.
+
+## Tests
+
+Add focused request tests for `/graphql`:
+
+- Public `RELATED` feed returns `articles` and `pagination`.
+- Public `OTHERS` feed returns `articles`.
+- Public `TAGGED` feed filters by keyword.
+- Authenticated request marks liked articles correctly.
+- `TAGGED` without `keyword` returns a GraphQL error.
+
+Existing REST tests should remain unchanged during the first migration step.
+
+## Rollout
+
+1. Add GraphQL server support and schema files.
+2. Add `articleFeed` query using existing `Articles::Query`.
+3. Verify GraphQL request tests pass.
+4. Keep existing REST endpoints in place.
+5. Update the iOS app to use `articleFeed`.
+6. Remove REST article list endpoints only after the iOS app no longer depends on them.
+
+## Non-Goals
+
+- No GraphQL mutations in the first pass.
+- No token refresh replacement in the first pass.
+- No article detail replacement in the first pass.
+- No comment, post, follow, or notification GraphQL API in the first pass.
+- No Relay connection schema in the first pass.

--- a/docs/superpowers/specs/2026-05-25-ios-graphql-article-feed-design.md
+++ b/docs/superpowers/specs/2026-05-25-ios-graphql-article-feed-design.md
@@ -39,7 +39,7 @@ query ArticleFeed(
   $kind: ArticleFeedKind!,
   $search: String,
   $keyword: String,
-  $page: Int,
+  $page: String,
   $limit: Int
 ) {
   articleFeed(kind: $kind, search: $search, keyword: $keyword, page: $page, limit: $limit) {
@@ -84,7 +84,7 @@ type Query {
     kind: ArticleFeedKind!,
     search: String,
     keyword: String,
-    page: Int,
+    page: String,
     limit: Int
   ): ArticleFeed!
 }
@@ -118,8 +118,8 @@ type Article {
 }
 
 type Pagination {
-  page: Int
-  nextPage: Int
+  page: String
+  nextPage: String
   limit: Int!
 }
 ```

--- a/test/controllers/graphql_controller_test.rb
+++ b/test/controllers/graphql_controller_test.rb
@@ -92,7 +92,7 @@ class GraphqlControllerTest < ActionDispatch::IntegrationTest
     liked_article = body.dig("data", "articleFeed", "articles").find { |item| item["slug"] == article.slug }
 
     assert_nil body["errors"]
-    assert_equal true, liked_article["liked"]
+    assert liked_article["liked"]
   end
 
   test "tagged feed requires keyword" do

--- a/test/controllers/graphql_controller_test.rb
+++ b/test/controllers/graphql_controller_test.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GraphqlControllerTest < ActionDispatch::IntegrationTest
+  ARTICLE_FEED_QUERY = <<~GRAPHQL
+    query ArticleFeed($kind: ArticleFeedKind!, $search: String, $keyword: String, $page: String, $limit: Int) {
+      articleFeed(kind: $kind, search: $search, keyword: $keyword, page: $page, limit: $limit) {
+        articles {
+          slug
+          title
+          titleKo
+          url
+          host
+          isRelated
+          likersCount
+          postsCount
+          summaryKey
+          tags
+          liked
+          publishedAt
+          createdAt
+          updatedAt
+        }
+        pagination {
+          page
+          nextPage
+          limit
+        }
+      }
+    }
+  GRAPHQL
+
+  test "public related feed returns articles and pagination" do
+    post graphql_path,
+         params: { query: ARTICLE_FEED_QUERY, variables: { kind: "RELATED" } },
+         as: :json
+
+    assert_response :success
+    body = JSON.parse(response.body)
+
+    assert_nil body["errors"]
+    assert_kind_of Array, body.dig("data", "articleFeed", "articles")
+    assert_kind_of Hash, body.dig("data", "articleFeed", "pagination")
+    assert_equal 15, body.dig("data", "articleFeed", "pagination", "limit")
+  end
+
+  test "public others feed returns articles" do
+    post graphql_path,
+         params: { query: ARTICLE_FEED_QUERY, variables: { kind: "OTHERS" } },
+         as: :json
+
+    assert_response :success
+    body = JSON.parse(response.body)
+
+    assert_nil body["errors"]
+    assert_kind_of Array, body.dig("data", "articleFeed", "articles")
+  end
+
+  test "public tagged feed filters by keyword" do
+    article = articles(:ruby_article)
+    make_visible_related_article(article)
+    article.tag_list.add("ruby")
+    article.save!
+
+    post graphql_path,
+         params: { query: ARTICLE_FEED_QUERY, variables: { kind: "TAGGED", keyword: "ruby" } },
+         as: :json
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    slugs = body.dig("data", "articleFeed", "articles").map { |item| item["slug"] }
+
+    assert_nil body["errors"]
+    assert_includes slugs, article.slug
+  end
+
+  test "authenticated related feed marks liked articles" do
+    user = users(:john)
+    article = articles(:ruby_article)
+    make_visible_related_article(article)
+    user.like!(article)
+    token = jwt_for(user)
+
+    post graphql_path,
+         params: { query: ARTICLE_FEED_QUERY, variables: { kind: "RELATED" } },
+         headers: { "Authorization" => token },
+         as: :json
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    liked_article = body.dig("data", "articleFeed", "articles").find { |item| item["slug"] == article.slug }
+
+    assert_nil body["errors"]
+    assert_equal true, liked_article["liked"]
+  end
+
+  test "tagged feed requires keyword" do
+    post graphql_path,
+         params: { query: ARTICLE_FEED_QUERY, variables: { kind: "TAGGED" } },
+         as: :json
+
+    assert_response :success
+    body = JSON.parse(response.body)
+
+    assert_nil body["data"]["articleFeed"]
+    assert_match "keyword is required for tagged article feed", body["errors"].first["message"]
+  end
+
+  private
+    def make_visible_related_article(article)
+      article.update!(
+        deleted_at: nil,
+        is_related: true,
+        title_ko: article.title_ko.presence || "루비 기사",
+        slug: article.slug.presence || "ruby-article",
+        published_at: article.published_at || Time.current
+      )
+    end
+
+    def jwt_for(user)
+      post user_session_path,
+           params: { user: { email: user.email, password: "password" } },
+           as: :json
+
+      response.headers.fetch("Authorization")
+    end
+end

--- a/test/controllers/graphql_controller_test.rb
+++ b/test/controllers/graphql_controller_test.rb
@@ -92,6 +92,7 @@ class GraphqlControllerTest < ActionDispatch::IntegrationTest
     liked_article = body.dig("data", "articleFeed", "articles").find { |item| item["slug"] == article.slug }
 
     assert_nil body["errors"]
+    assert_not_nil liked_article
     assert liked_article["liked"]
   end
 
@@ -103,7 +104,7 @@ class GraphqlControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     body = JSON.parse(response.body)
 
-    assert_nil body["data"]["articleFeed"]
+    assert_nil body["data"]
     assert_match "keyword is required for tagged article feed", body["errors"].first["message"]
   end
 


### PR DESCRIPTION
## Summary
- iOS 앱 마이그레이션을 위한 `POST /graphql` 엔드포인트와 `articleFeed` 쿼리 추가 (RELATED/OTHERS/TAGGED)
- 기존 `Articles::Query`와 Pagy keyset 페이지네이션 재사용, 인증 시 `liked` 필드 개인화
- 기존 REST 엔드포인트는 그대로 유지 (iOS 마이그레이션 완료 후 제거)

## Test Plan
- [x] GraphQL 컨트롤러 테스트 5/5 통과 (public RELATED/OTHERS/TAGGED, 인증 liked, TAGGED keyword 누락 에러)
- [x] 기존 REST API 테스트 4/4 통과
- [x] 품질 게이트 4/4 통과 (line 77.81%, branch 59.02%)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * GraphQL 기반 아티클 피드 조회 API 추가 (`POST /graphql` 엔드포인트)
  * 다양한 필터링 옵션 지원: 관련 문서, 기타 문서, 키워드 기반 태그 검색
  * 키셋 기반 페이지네이션 기능 제공
  * 사용자 인증 시 각 아티클의 좋아요 여부 표시
  * 선택적 JWT 인증 지원으로 개인화된 콘텐츠 제공

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stadia/ra-news/pull/730?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->