### PR TITLE
GEO 감사 리포트 지적사항 수정

### DIFF
--- a/app/components/layout.rb
+++ b/app/components/layout.rb
@@ -17,7 +17,9 @@ class Components::Layout < Components::Base
         render_rss_link
         csrf_meta_tags
         csp_meta_tag
-        yield(:head)
+        # Per-view <head> additions (e.g. page-specific meta tags). content_for is a
+        # Phlex value helper, so the buffer must be emitted explicitly with raw.
+        raw(content_for(:head)) if content_for?(:head)
         render_pwa_and_icons
         render_google_fonts
         stylesheet_link_tag :app, data_turbo_track: "reload"
@@ -173,10 +175,11 @@ class Components::Layout < Components::Base
 
   def render_schema_org
     vc = view_context
-    web_site = vc.instance_variable_get(:@web_site)
-    news_media = vc.instance_variable_get(:@news_media_organization)
-    raw(web_site.to_s) if web_site
-    raw(news_media.to_s) if news_media
+    # Controller instance variables (Phlex views don't inherit them, so read via view_context).
+    %i[@web_site @news_media_organization @news_article @breadcrumbs].each do |ivar|
+      schema = vc.instance_variable_get(ivar)
+      raw(schema.to_s) if schema
+    end
   end
 
   def render_skip_link

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -17,6 +17,7 @@ class HomeController < ApplicationController
 
   def index
     cacheable_page!
+    @page_description = t("home.index.meta_description")
     scope = article_scope
 
     @featured_articles = build_featured_articles(scope)

--- a/app/views/articles/show.rb
+++ b/app/views/articles/show.rb
@@ -18,10 +18,8 @@ class Views::Articles::Show < Views::Base
   def view_template
     content_for(:title, @article.display_title)
 
-    # @news_article, @breadcrumbs are set as instance variables in ArticlesController#show
-    # Insert schema.org JSON-LD into layout's head via content_for(:head)
-    content_for :head, raw(@news_article.to_s) if @news_article
-    content_for :head, raw(@breadcrumbs.to_s) if @breadcrumbs
+    # @news_article and @breadcrumbs (set in ArticlesController#show) are rendered as
+    # schema.org JSON-LD by Components::Layout#render_schema_org via view_context.
 
     div(class: "space-y-6 lg:space-y-8 max-w-6xl mx-auto", id: dom_id(@article)) do
       render_article_main

--- a/app/views/home/index.rb
+++ b/app/views/home/index.rb
@@ -17,6 +17,10 @@ class Views::Home::Index < Views::Base
 
     render_item_list_schema
 
+    # Single semantic page heading for accessibility and search/AI topical clarity.
+    # Visually hidden so the existing featured-first layout is unchanged.
+    h1(class: "sr-only") { t("home.index.page_heading") }
+
     div(class: "flex flex-col lg:flex-row gap-6") do
       div(class: "flex-1 min-w-0") do
         if @featured_articles.any?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,7 +147,9 @@ en:
     index:
       item_list_name: Ruby-News Latest News
       latest_news: Latest News
+      meta_description: Daily AI-assisted summaries of Ruby & Rails ecosystem news — version releases, security advisories (CVEs), tutorials and conferences — each with a 3-point key summary and a link to the original source.
       more_articles: View more articles
+      page_heading: AI-Translated Ruby & Rails News for Developers
       title: Ruby-News | AI News for Ruby & Rails Developers
     rss:
       description: The latest Ruby and Rails news and trends in one place

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -147,7 +147,9 @@ ja:
     index:
       item_list_name: Ruby-News 最新ニュース
       latest_news: 最新ニュース
+      meta_description: 世界中のRuby・RailsエコシステムのニュースをAI補助翻訳で毎日日本語要約。バージョンリリース、セキュリティ勧告(CVE)、チュートリアル、カンファレンス情報を3行の要点と元記事リンク付きでお届けします。
       more_articles: 過去の記事をもっと見る
+      page_heading: Ruby・Rails開発者のための日本語AIニュース
       title: Ruby-News | Ruby・Rails開発者のためのAIニュース
     rss:
       description: Ruby、Rails関連の最新ニュースとトレンドをまとめてお届けします

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -147,7 +147,9 @@ ko:
     index:
       item_list_name: Ruby-News 최신 뉴스
       latest_news: 최신 뉴스
+      meta_description: 전 세계 Ruby·Rails 생태계 뉴스를 매일 AI 보조 번역으로 한국어 요약 제공. 버전 릴리즈, 보안 권고(CVE), 튜토리얼, 컨퍼런스 소식을 핵심 3줄 요약과 원문 출처 링크와 함께 전합니다.
       more_articles: 지난 글 더 보기
+      page_heading: 루비·Rails 개발자를 위한 한국어 AI 뉴스
       title: Ruby-News | 루비·Rails 개발자를 위한 AI 뉴스
     rss:
       description: 최신 Ruby, Rails 관련 뉴스와 트렌드를 한곳에서 만나보세요

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,12 @@
 # https://www.robotstxt.org/robotstxt.html
-
+#
+# Content-Signal (https://contentsignals.org) declares how this site's content
+# may be used by automated agents:
+#   search=yes    : indexing for search results (links + short excerpts) — allowed
+#   ai-input=yes  : real-time use in AI answers / RAG / grounding (citation) — allowed
+#   ai-train=no   : training or fine-tuning AI models — not allowed
 User-agent: *
+Content-Signal: search=yes,ai-input=yes,ai-train=no
 Disallow: /login
 Disallow: /logout
 Disallow: /signup
@@ -10,27 +16,19 @@ Disallow: /madmin
 Disallow: /jobs
 Disallow: /pg_reports
 
+# SEO crawler we don't want
 User-agent: SemrushBot
 Disallow: /
 
-# AI 인용 크롤러 (Perplexity 등) - 허용
+# AI 인용 크롤러 (Perplexity 등) - 허용 (AI 답변에 우리 콘텐츠가 인용되도록)
 User-agent: PerplexityBot
 Allow: /
 
-# AI 학습 데이터 크롤러 - 차단
-User-agent: GPTBot
-Disallow: /
-
-User-agent: CCBot
-Disallow: /
-
-User-agent: Google-Extended
-Disallow: /
-
+# AI 학습 데이터 크롤러 - 차단 (Content-Signal ai-train=no 와 일관).
+# 참고: GPTBot, CCBot, ClaudeBot, Google-Extended 등 주요 크롤러는 이미
+# Cloudflare Managed Robots 에서 차단되므로, 단일 출처 유지를 위해 여기서
+# 중복 선언하지 않는다. 관리 목록에 없는 에이전트만 아래에 명시한다.
 User-agent: anthropic-ai
-Disallow: /
-
-User-agent: ClaudeBot
 Disallow: /
 
 Sitemap: https://ruby-news.dev/sitemaps/sitemap.xml.gz

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -101,6 +101,26 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", text: /#{Regexp.escape(article.title_ko)}/
   end
 
+  test "GET show emits NewsArticle and BreadcrumbList JSON-LD in head" do
+    article = articles(:ruby_article)
+    get article_path(article)
+
+    assert_response :success
+
+    ld_blocks = css_select("script[type='application/ld+json']").map { |n| JSON.parse(n.text) }
+    news_article = ld_blocks.find { |b| b["@type"] == "NewsArticle" }
+    breadcrumbs  = ld_blocks.find { |b| b["@type"] == "BreadcrumbList" }
+
+    assert news_article, "expected a NewsArticle JSON-LD block, got types: #{ld_blocks.map { |b| b["@type"] }.inspect}"
+    assert_equal article.display_title, news_article["headline"]
+    assert_equal "ko-KR", news_article["inLanguage"]
+    assert_equal article.url, news_article["isBasedOn"]
+    assert_equal "Ruby-News", news_article.dig("publisher", "name")
+    assert news_article["datePublished"].present?, "datePublished should be set"
+
+    assert breadcrumbs, "expected a BreadcrumbList JSON-LD block"
+  end
+
   test "GET new renders intake form for authenticated user" do
     sign_in_as(users(:john))
 


### PR DESCRIPTION
GEO-AUDIT-REPORT.md에서 확인된 문제들을 해결한다.

- 아티클 스키마 렌더링 버그 수정 (리포트 H1/M3, 실제로는 코드 버그): @news_article / @breadcrumbs 는 컨트롤러 인스턴스 변수인데 Phlex 뷰(show.rb)에서 @ivar 로 접근해 항상 nil 이라 NewsArticle · BreadcrumbList JSON-LD 가 전혀 출력되지 않았다. 홈페이지 스키마와 동일하게 layout 의 render_schema_org 에서 view_context 로 읽어 렌더. 깨져 있던 yield(:head) 를 올바른 Phlex 관용구 raw(content_for(:head)) 로 교체.
- robots.txt: Content-Signal 에 ai-input=yes 추가(인용 의도 명시), Cloudflare Managed Robots 와 중복되던 GPTBot/CCBot/ClaudeBot/Google-Extended 선언 제거로 단일 출처화 (리포트 M1/H3).
- 홈페이지에 시맨틱 h1 추가 (sr-only, 레이아웃 불변) (리포트 M2).
- 홈페이지 meta description 을 서비스 특성(AI 번역·일일 요약·핵심 3줄)으로 차별화 (리포트 L2).
- ko/ja/en 로케일에 page_heading, meta_description 키 추가.
- 아티클 JSON-LD 회귀 테스트 추가.