### PR TITLE
federails 잡 큐 분리 및 호스트 동기화 일정 추가

### DIFF
--- a/config/federails.yml
+++ b/config/federails.yml
@@ -12,6 +12,7 @@ defaults: &defaults
   server_routes_path: federation
   #remote_entities_cache_duration: 86400 # 1 day in seconds
   base_client_controller: Federails::ApplicationController
+  job_queue: federation
 
 development:
   <<: *defaults

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -32,3 +32,7 @@ production:
   japanese_temp_job:
     class: "JapaneseTempJob"
     schedule: "*/20 * * * *"
+  federails_sync_hosts:
+    command: "Federails::Maintenance::HostsUpdater.run"
+    schedule: "15 3 * * *"
+    queue: federation


### PR DESCRIPTION
## Summary
- federails outbound delivery(`NotifyInboxJob` 등)를 `default` 큐에서 분리해 `federation` 전용 큐 사용. 외부 서버 응답 지연이 다른 백그라운드 잡 처리에 영향 주지 않도록 격리.
- federails 0.8.0의 `Federails::Host` 메타데이터를 매일 03:15 KST에 `Federails::Maintenance::HostsUpdater.run`으로 동기화. nodeinfo/소프트웨어 버전 등이 최신 상태로 유지됨.
- solid_queue worker가 `queues: "*"`로 모든 큐를 처리하므로 워커 설정 변경 불필요.

## Test plan
- [x] `bin/rails runner 'puts Federails::Configuration.job_queue.inspect'` → `\"federation\"` 로드 확인
- [x] `bin/rails test` — 690 runs / 2240 assertions / 0 failures
- [ ] 배포 후 SolidQueue 대시보드에서 `federation` 큐 생성 및 `federails_sync_hosts` 작업 등록 확인

## Notes
- 본 PR은 #745 (Socialization 제거 + federails 좋아요 통합)와 독립. 머지 순서 무관.
- 별도 워커 풀로 분리하고 싶다면 추후 `config/queue.yml`에 `queues: federation` 워커를 추가해 분리 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)