### PR TITLE
remote DataEntity에 대한 outbound Like 누락 회귀 수정

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/stadia/federails.git
-  revision: 6c85a53ca5a2fd6e30902e2831100814e9e1aa52
+  revision: faf0090f0bbfa9607932204d04e0bc682c9f6052
   specs:
     federails (0.8.0)
       alba (~> 3.0)

--- a/test/models/like_test.rb
+++ b/test/models/like_test.rb
@@ -80,6 +80,30 @@ class LikeTest < ActiveSupport::TestCase
     assert_equal @local_article, activity.entity
   end
 
+  test "local user liking a remote post creates an outbound Like activity" do
+    assert_difference("Federails::Activity.where(action: 'Like').count", 1) do
+      @user.like!(@remote_post)
+    end
+
+    activity = Federails::Activity.where(action: "Like").order(created_at: :desc).first
+
+    assert_equal @user.federails_actor, activity.actor
+    assert_equal @remote_post, activity.entity
+  end
+
+  test "local user unliking a remote post creates an Undo activity" do
+    @user.like!(@remote_post)
+
+    assert_difference("Federails::Activity.where(action: 'Undo').count", 1) do
+      @user.unlike!(@remote_post)
+    end
+
+    undo = Federails::Activity.where(action: "Undo").order(created_at: :desc).first
+
+    assert_instance_of Federails::Activity, undo.entity
+    assert_equal "Like", undo.entity.action
+  end
+
   test "remote actor like via inbound handler creates a Like row and updates counters" do
     activity = {
       "id" => "https://remote.example/activities/like-1",


### PR DESCRIPTION
## Summary
외부 federation으로 들어온 remote Post에 좋아요를 눌러도 `Federails::Activity`(Like)가 만들어지지 않고 `NotifyInboxJob`도 큐잉되지 않는 회귀를 수정.

## 원인
federails 0.8.x의 `Federails::DataEntity#create_federails_activity` 는 모든 outgoing activity 를 `local_federails_entity?` 로 게이트한다. 이 게이트는 라이프사이클(Create/Update/Delete) 활동에만 의미가 있고, 소셜 활동(Like/Dislike/Announce)은 actor 가 local 이면 remote 엔티티를 대상으로도 정상 발사되어야 한다(canonical AP 흐름). 비교: `Federails::Following` 은 이 게이트를 거치지 않고 `Activity.create!` 를 직접 호출하므로 outbound Follow 는 remote 대상으로도 동작한다.

## 수정
stadia/federails#20 에서 게이트를 액션 종류별로 분리.
- 라이프사이클(Create/Update/Delete): `local_federails_entity? && should_federate?` 유지
- 소셜(Like/Dislike/Announce/Undo): `actor&.local?` 만 검증

본 PR 은 해당 패치가 포함된 federails 리비전(stadia/federails@faf0090)으로 Gemfile.lock 을 갱신하고, 로컬 사용자 → remote post 시나리오 회귀 테스트 2개를 추가.

## Test plan
- [x] `bundle exec rspec` (federails) — 791 examples, 0 failures
- [x] `bin/rails test test/models/like_test.rb` — 11 runs, 40 assertions, 0 failures
- [x] `bin/rails test` — 691 runs, 2220 assertions, 0 failures
- [ ] 운영 배포 후 외부 글(remote post)에 좋아요 → SolidQueue 의 federation 큐에 `Federails::NotifyInboxJob` 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)