### PR TITLE
장문(Longform) 데이터 모델·마이그레이션

### DIFF
--- a/app/models/concerns/posts/longform.rb
+++ b/app/models/concerns/posts/longform.rb
@@ -35,7 +35,7 @@ module Posts
 
     #: () -> String
     def longform_summary
-      stripped = ActionView::Base.full_sanitizer.sanitize(body.to_s).squish
+      stripped = Rails::Html::FullSanitizer.new.sanitize(body.to_s).squish
       stripped.truncate(LONGFORM_SUMMARY_LENGTH)
     end
 

--- a/app/models/concerns/posts/longform.rb
+++ b/app/models/concerns/posts/longform.rb
@@ -12,42 +12,15 @@ module Posts
 
     LONGFORM_SUMMARY_LENGTH = 280
 
-    # Prepended onto the including class so it sits ahead of
-    # Federails::DataEntity in the ancestor chain. That lets us swallow the
-    # automatic "Update" activity fired during a draft's first publish; publish!
-    # emits a "Create" explicitly instead (see #publish!).
-    module FederailsActivityOverride
-      private
-
-      def create_federails_activity(action, **)
-        return if action == "Update" && @suppress_federails_update
-
-        super
-      end
-    end
-
     included do
       validate :validate_longform_draft_content
-      prepend FederailsActivityOverride
     end
 
     #: () -> void
     def publish!
-      # A draft never federated, so remotes hold no object for it. Federails'
-      # after_update would emit an "Update" on this save, which remotes drop
-      # (nothing to update). Suppress that Update and emit a "Create" instead so
-      # the first publish actually delivers the post. Re-publishing an already
-      # published post keeps the normal Update path.
-      publishing_draft = draft?
-      @suppress_federails_update = publishing_draft
-
       self.published_at ||= Time.current
       self.status = :published
       save!
-
-      create_federails_activity("Create") if publishing_draft && should_federate?
-    ensure
-      @suppress_federails_update = false
     end
 
     #: () -> bool

--- a/app/models/concerns/posts/longform.rb
+++ b/app/models/concerns/posts/longform.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Longform-specific behavior for Post: publishing, draft/published predicates,
+# summary generation, and draft content validation.
+#
+# The post_type/status enums and longform scopes remain on Post itself,
+# since they are referenced as class methods elsewhere.
+module Posts
+  module Longform
+    extend ActiveSupport::Concern
+
+    LONGFORM_SUMMARY_LENGTH = 280
+
+    # Prepended onto the including class so it sits ahead of
+    # Federails::DataEntity in the ancestor chain. That lets us swallow the
+    # automatic "Update" activity fired during a draft's first publish; publish!
+    # emits a "Create" explicitly instead (see #publish!).
+    module FederailsActivityOverride
+      private
+
+      def create_federails_activity(action, **)
+        return if action == "Update" && @suppress_federails_update
+
+        super
+      end
+    end
+
+    included do
+      validate :validate_longform_draft_content
+      prepend FederailsActivityOverride
+    end
+
+    #: () -> void
+    def publish!
+      # A draft never federated, so remotes hold no object for it. Federails'
+      # after_update would emit an "Update" on this save, which remotes drop
+      # (nothing to update). Suppress that Update and emit a "Create" instead so
+      # the first publish actually delivers the post. Re-publishing an already
+      # published post keeps the normal Update path.
+      publishing_draft = draft?
+      @suppress_federails_update = publishing_draft
+
+      self.published_at ||= Time.current
+      self.status = :published
+      save!
+
+      create_federails_activity("Create") if publishing_draft && should_federate?
+    ensure
+      @suppress_federails_update = false
+    end
+
+    #: () -> bool
+    def draft_longform?
+      longform? && draft?
+    end
+
+    #: () -> bool
+    def published_longform?
+      longform? && published?
+    end
+
+    #: () -> String
+    def longform_summary
+      stripped = ActionView::Base.full_sanitizer.sanitize(body.to_s).squish
+      stripped.truncate(LONGFORM_SUMMARY_LENGTH)
+    end
+
+    private
+
+    #: () -> void
+    def validate_longform_draft_content
+      return unless draft_longform?
+      return if title.present? || body.present?
+
+      errors.add(:base, I18n.t("posts.longform.errors.blank_draft"))
+    end
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -167,6 +167,14 @@ class Post < ApplicationRecord
     actor ||= federails_actor || user&.federails_actor
     return if actor.blank?
 
+    # A draft never federated, so its first publish fires an "Update" (via the
+    # after_update callback) that remotes would drop — there's no object to
+    # update yet. Promote that first Update to a "Create" so the post is
+    # actually delivered. Once a Create exists, later edits federate as Updates.
+    if action == "Update" && !Federails::Activity.exists?(entity: self, action: "Create")
+      action = "Create"
+    end
+
     super(action, actor: actor, to: to, cc: cc)
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -11,13 +11,21 @@ class Post < ApplicationRecord
 
   # ── Includes ─────────────────────────────────────────────────────────
   include HtmlSanitizable
+  include Posts::Longform
+  include Discard::Model
   include Federails::DataEntity
   include FederailsLikeable
   include FederailsBoostable
 
+  self.discard_column = :deleted_at
+
   # ── Framework Macros ─────────────────────────────────────────────────
   acts_as_nested_set
   acts_as_taggable_on :tags
+
+  # ── Enums ────────────────────────────────────────────────────────────
+  enum :post_type, [ :short, :longform, :comment ], default: :short
+  enum :status, [ :draft, :published ], default: :published
 
   # ── Associations ─────────────────────────────────────────────────────
   belongs_to :user, optional: true
@@ -25,11 +33,14 @@ class Post < ApplicationRecord
   belongs_to :federails_actor, class_name: "Federails::Actor", optional: true
 
   # ── Scopes ───────────────────────────────────────────────────────────
-  scope :comments, -> { where.not(article_id: nil) }
+  scope :comments, -> { where(post_type: :comment) }
   scope :standalone, -> { where(article_id: nil) }
+  scope :visible, -> { where(status: :published).kept }
+  scope :published_longform, -> { longform.published }
 
   # ── Validations ──────────────────────────────────────────────────────
-  validates :body, presence: true
+  validates :body, presence: true, unless: :draft_longform?
+  validates :title, presence: true, if: :published_longform?
   validates :slug, uniqueness: true, allow_nil: true
   validate :validate_user_or_actor
   validate :validate_parent_post
@@ -47,12 +58,24 @@ class Post < ApplicationRecord
   after_commit :enqueue_reply_notification, on: :create
   after_commit :enqueue_article_thumbnail, on: :create
 
+  # ── Soft delete ──────────────────────────────────────────────────────
+  # Only published posts were ever federated, so only they emit Delete/Undo.
+  # Drafts are local-only, so discarding/restoring one federates nothing.
+  after_discard { create_federails_activity "Delete" if published? }
+  after_undiscard { create_federails_activity "Undo" if published? }
+
   # ── Federation ───────────────────────────────────────────────────────
   acts_as_federails_data handles: "Note",
                          actor_entity_method: :federation_actor_entity,
+                         soft_deleted_method: :discarded?,
+                         soft_delete_date_method: :deleted_at,
                          should_federate_method: :should_federate?
 
-  on_federails_delete_requested -> { logger.info { "Federated post deletion requested #{id}" }; destroy! }
+  # Only longform posts support soft delete (trash/restore). Short posts and
+  # comments hard-destroy, both locally and on inbound federated Delete, so
+  # their rows (and counter caches) are removed as before.
+  on_federails_delete_requested -> { logger.info { "Federated post deletion requested #{id}" }; longform? ? discard! : destroy! }
+  on_federails_undelete_requested :undiscard!
 
   # ── Public Instance Methods ──────────────────────────────────────────
 
@@ -63,7 +86,11 @@ class Post < ApplicationRecord
 
   #: () -> bool
   def should_federate?
-    federation_actor_entity.present?
+    # Only published posts federate. Drafts must stay local — without the
+    # published? gate, Federails' after_create/after_update would push an
+    # unpublished draft (and every autosave) to remote followers. Discarded
+    # posts keep status :published, so after_discard can still emit a Delete.
+    federation_actor_entity.present? && published?
   end
 
   #: () -> Hash[String, untyped]
@@ -85,7 +112,16 @@ class Post < ApplicationRecord
       custom["attachment"] = media_attachments
     end
 
-    Federails::DataTransformer::Note.to_federation(self, content: body, custom: custom)
+    content = body
+    name = nil
+
+    if longform?
+      content = longform_summary
+      name = title
+      custom["url"] = Rails.application.routes.url_helpers.post_url(self)
+    end
+
+    Federails::DataTransformer::Note.to_federation(self, content: content, name: name, custom: custom)
   end
 
   #: () -> Integer
@@ -96,11 +132,6 @@ class Post < ApplicationRecord
   #: () -> Integer
   def boosts_count
     boosters_count.to_i
-  end
-
-  #: () -> bool
-  def comment?
-    article_id.present?
   end
 
   #: () -> (Post | Article)
@@ -214,23 +245,7 @@ class Post < ApplicationRecord
         body: extract_body_from_activitypub_object(hash, attachments:)
       }
 
-      if in_reply_to.present?
-        article_id = in_reply_to[%r{/articles/(\d+)}, 1]
-        post_id = in_reply_to[%r{/posts/(\d+)}, 1]
-
-        if article_id.present?
-          object[:article_id] = article_id
-        elsif post_id.present?
-          object[:parent_id] = post_id
-          object[:article_id] = Post.where(id: post_id).pick(:article_id)
-        else
-          parent = Post.find_by(federated_url: in_reply_to)
-          if parent
-            object[:parent_id] = parent.id
-            object[:article_id] = parent.article_id
-          end
-        end
-      end
+      object.merge!(reply_attributes(in_reply_to)) if in_reply_to.present?
 
       # Mastodon 이미지 첨부 파싱
       object[:media_attachments] = attachments.map do |a|
@@ -245,6 +260,30 @@ class Post < ApplicationRecord
     end
 
     private
+
+    # Resolves the reply target (article comment, post reply, or federated
+    # parent) from an inReplyTo URL into attributes for from_activitypub_object.
+    # Inbound replies to an article are typed :comment so they stay in the
+    # `comments` scope instead of defaulting to :short.
+    #: (String) -> Hash[Symbol, untyped]
+    def reply_attributes(in_reply_to)
+      attrs = reply_target_attributes(in_reply_to)
+      attrs[:post_type] = :comment if attrs[:article_id].present?
+      attrs
+    end
+
+    #: (String) -> Hash[Symbol, untyped]
+    def reply_target_attributes(in_reply_to)
+      if (article_id = in_reply_to[%r{/articles/(\d+)}, 1])
+        { article_id: article_id }
+      elsif (post_id = in_reply_to[%r{/posts/(\d+)}, 1])
+        { parent_id: post_id, article_id: Post.where(id: post_id).pick(:article_id) }
+      elsif (parent = Post.find_by(federated_url: in_reply_to))
+        { parent_id: parent.id, article_id: parent.article_id }
+      else
+        {}
+      end
+    end
 
     #: (Hash[String, untyped], attachments: Array[Hash[String, untyped]]) -> String
     def extract_body_from_activitypub_object(hash, attachments:)

--- a/db/migrate/20260608222813_add_longform_state_to_posts.rb
+++ b/db/migrate/20260608222813_add_longform_state_to_posts.rb
@@ -13,7 +13,7 @@ class AddLongformStateToPosts < ActiveRecord::Migration[8.1]
       UPDATE posts
       SET post_type = CASE WHEN article_id IS NULL THEN 0 ELSE 2 END,
           status = 1,
-          published_at = COALESCE(created_at, NOW())
+          published_at = COALESCE(created_at, timezone('utc', now()))
     SQL
   end
 

--- a/db/migrate/20260608222813_add_longform_state_to_posts.rb
+++ b/db/migrate/20260608222813_add_longform_state_to_posts.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class AddLongformStateToPosts < ActiveRecord::Migration[8.1]
+  def up
+    add_column :posts, :post_type, :integer, null: false, default: 0
+    add_column :posts, :status, :integer, null: false, default: 1
+    add_column :posts, :published_at, :datetime
+
+    add_index :posts, [ :post_type, :status, :created_at ], name: "index_posts_on_type_status_created_at"
+    add_index :posts, [ :user_id, :post_type, :status, :created_at ], name: "index_posts_on_user_type_status_created_at"
+
+    execute <<~SQL.squish
+      UPDATE posts
+      SET post_type = CASE WHEN article_id IS NULL THEN 0 ELSE 2 END,
+          status = 1,
+          published_at = COALESCE(created_at, NOW())
+    SQL
+  end
+
+  def down
+    remove_index :posts, name: "index_posts_on_user_type_status_created_at"
+    remove_index :posts, name: "index_posts_on_type_status_created_at"
+    remove_column :posts, :published_at
+    remove_column :posts, :status
+    remove_column :posts, :post_type
+  end
+end

--- a/db/migrate/20260609010000_add_deleted_at_to_posts.rb
+++ b/db/migrate/20260609010000_add_deleted_at_to_posts.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToPosts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :posts, :deleted_at, :datetime
+    add_index :posts, :deleted_at
+  end
+end

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -27,6 +27,42 @@ comment_post:
   body: "기사에 달린 댓글입니다."
   user: john
   article: ruby_article
+  post_type: 2
+  status: 1
   lft: 7
   rgt: 8
+  depth: 0
+
+longform_draft:
+  title: "작성 중인 긴 글"
+  body: "<p>초안 본문입니다.</p>"
+  user: john
+  post_type: 1
+  status: 0
+  slug: "lf-draft-fixture"
+  lft: 9
+  rgt: 10
+  depth: 0
+
+longform_published:
+  title: "발행된 긴 글"
+  body: "<p>발행된 장문 본문입니다. Ruby와 Rails에 대한 긴 글입니다.</p>"
+  user: john
+  post_type: 1
+  status: 1
+  published_at: <%= 2.days.ago %>
+  slug: "lf-published-fixture"
+  lft: 11
+  rgt: 12
+  depth: 0
+
+# article_id가 있어도 post_type이 comment가 아니면 comment?는 false임을 고정
+short_with_article:
+  body: "기사에 연결됐지만 댓글 타입은 아닌 단문입니다."
+  user: john
+  article: ruby_article
+  post_type: 0
+  status: 1
+  lft: 13
+  rgt: 14
   depth: 0

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -629,15 +629,16 @@ class PostTest < ActiveSupport::TestCase
     end
   end
 
-  # 이미 발행된 글을 다시 publish!하면 원격에 객체가 존재하므로 일반 Update 경로를
-  # 유지한다(Create 억제는 draft→published 최초 전환에만 적용).
-  test "publish!는 이미 발행된 글에는 일반 Update 경로를 유지한다" do
+  # 이미 Create를 발행한(원격에 객체가 존재하는) 글의 수정은 일반 Update 경로를
+  # 유지한다. Create 승격은 Create 활동이 없는 최초 발행에만 적용된다.
+  test "이미 Create가 발행된 글의 수정은 Update 경로를 유지한다" do
     post = posts(:longform_published)
-    post.body = "재발행 시 본문 변경"
+    Federails::Activity.create!(actor: federails_actors(:john_actor), entity: post, action: "Create")
+    post.body = "수정된 본문"
 
     assert_difference -> { Federails::Activity.where(action: "Update", entity: post).count }, 1 do
       assert_no_difference -> { Federails::Activity.where(action: "Create", entity: post).count } do
-        post.publish!
+        post.save!
       end
     end
   end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -115,12 +115,23 @@ class PostTest < ActiveSupport::TestCase
 
   # ========== Article Comment Tests ==========
 
-  test "comment?는 article_id가 있으면 true를 반환한다" do
+  test "comment?는 post_type이 comment이면 true를 반환한다" do
     assert_predicate @comment_post, :comment?
   end
 
-  test "comment?는 article_id가 없으면 false를 반환한다" do
+  test "comment?는 post_type이 short이면 false를 반환한다" do
     assert_not @root_post.comment?
+  end
+
+  test "comment?는 post_type이 longform이면 false를 반환한다" do
+    assert_not posts(:longform_published).comment?
+  end
+
+  test "comment?는 article_id가 있어도 post_type이 comment가 아니면 false를 반환한다" do
+    short_with_article = posts(:short_with_article)
+
+    assert_predicate short_with_article.article_id, :present?
+    assert_not short_with_article.comment?
   end
 
   test "reply는 parent가 있으면 parent를 반환한다" do
@@ -160,11 +171,13 @@ class PostTest < ActiveSupport::TestCase
 
   # ========== Scope Tests ==========
 
-  test "comments 스코프는 article_id가 있는 post만 반환한다" do
+  test "comments 스코프는 post_type이 comment인 post만 반환한다" do
     comments = Post.comments
 
     assert_includes comments, @comment_post
     assert_not_includes comments, @root_post
+    assert_not_includes comments, posts(:longform_published)
+    assert_not_includes comments, posts(:short_with_article)
   end
 
   test "standalone 스코프는 article_id가 없는 post만 반환한다" do
@@ -172,6 +185,132 @@ class PostTest < ActiveSupport::TestCase
 
     assert_includes standalone, @root_post
     assert_not_includes standalone, @comment_post
+  end
+
+  # ========== Longform / Enum Tests ==========
+
+  test "post_type enum은 short longform comment를 제공한다" do
+    assert_equal %w[short longform comment], Post.post_types.keys
+  end
+
+  test "status enum은 draft published를 제공한다" do
+    assert_equal %w[draft published], Post.statuses.keys
+  end
+
+  test "삭제는 Discard::Model로 처리한다" do
+    assert_includes Post.included_modules, Discard::Model
+    assert_equal :deleted_at, Post.discard_column
+  end
+
+  test "기존 단문은 제목 없이 published short로 유효하다" do
+    post = Post.new(body: "단문", user: @user)
+
+    assert_predicate post, :valid?, post.errors.full_messages.join(", ")
+    assert_predicate post, :short?
+    assert_predicate post, :published?
+  end
+
+  test "기사 댓글은 comment 타입으로 지정할 수 있다" do
+    post = Post.new(body: "댓글", user: @user, article: @article, post_type: :comment)
+
+    assert_predicate post, :valid?, post.errors.full_messages.join(", ")
+    assert_predicate post, :comment?
+  end
+
+  test "장문 초안은 제목만 있으면 저장할 수 있다" do
+    post = Post.new(title: "초안 제목", body: "", user: @user, post_type: :longform, status: :draft)
+
+    assert_predicate post, :valid?, post.errors.full_messages.join(", ")
+  end
+
+  test "장문 초안은 본문만 있으면 저장할 수 있다" do
+    post = Post.new(title: "", body: "<p>초안 본문</p>", user: @user, post_type: :longform, status: :draft)
+
+    assert_predicate post, :valid?, post.errors.full_messages.join(", ")
+  end
+
+  test "완전히 비어 있는 장문 초안은 유효하지 않다" do
+    post = Post.new(title: "", body: "", user: @user, post_type: :longform, status: :draft)
+
+    assert_not post.valid?
+    assert_predicate post.errors[:base], :any?
+  end
+
+  test "발행 장문은 제목과 본문이 필요하다" do
+    missing_title = Post.new(body: "<p>본문</p>", user: @user, post_type: :longform, status: :published)
+    missing_body = Post.new(title: "제목", body: "", user: @user, post_type: :longform, status: :published)
+
+    assert_not missing_title.valid?
+    assert_predicate missing_title.errors[:title], :any?
+    assert_not missing_body.valid?
+    assert_predicate missing_body.errors[:body], :any?
+  end
+
+  test "published_longform 스코프는 발행된 장문만 반환한다" do
+    draft = posts(:longform_draft)
+    published = posts(:longform_published)
+
+    assert_includes Post.published_longform, published
+    assert_not_includes Post.published_longform, draft
+    assert_not_includes Post.published_longform, @root_post
+  end
+
+  test "longform_summary는 HTML을 제거하고 앞부분을 반환한다" do
+    post = Post.new(body: "<p>Ruby <strong>Rails</strong> 장문입니다.</p>", user: @user, post_type: :longform)
+
+    assert_equal "Ruby Rails 장문입니다.", post.longform_summary
+  end
+
+  test "from_activitypub_object은 기사 답글을 comment 타입으로 지정한다" do
+    host = Rails.application.routes.default_url_options[:host]
+    hash = {
+      "id" => "https://remote.example/notes/comment-1",
+      "content" => "기사에 대한 원격 댓글",
+      "inReplyTo" => "https://#{host}/articles/#{@article.id}"
+    }
+
+    object = Post.from_activitypub_object(hash)
+
+    assert_equal @article.id.to_s, object[:article_id]
+    assert_equal :comment, object[:post_type]
+  end
+
+  test "from_activitypub_object은 기사가 아닌 답글에는 post_type을 지정하지 않는다" do
+    hash = {
+      "id" => "https://remote.example/notes/standalone-1",
+      "content" => "원문 노트"
+    }
+
+    object = Post.from_activitypub_object(hash)
+
+    assert_nil object[:post_type]
+    assert_nil object[:article_id]
+  end
+
+  test "발행된 장문을 discard하면 Delete 활동이 생성된다" do
+    published = posts(:longform_published)
+
+    assert_difference -> { Federails::Activity.where(action: "Delete", entity: published).count }, 1 do
+      published.discard!
+    end
+  end
+
+  test "발행된 장문을 undiscard하면 Undo 활동이 생성된다" do
+    published = posts(:longform_published)
+    published.discard!
+
+    assert_difference -> { Federails::Activity.where(action: "Undo", entity: published).count }, 1 do
+      published.undiscard!
+    end
+  end
+
+  test "초안 장문을 undiscard해도 Undo 활동이 생성되지 않는다" do
+    draft = posts(:longform_draft)
+    draft.discard!
+
+    assert_no_difference -> { Federails::Activity.where(action: "Undo").count } do
+      draft.undiscard!
+    end
   end
 
   # ========== handle_federated_object? Tests ==========
@@ -334,7 +473,7 @@ class PostTest < ActiveSupport::TestCase
     post.tag_list = "ruby, rails"
 
     captured = nil
-    Federails::DataTransformer::Note.stub(:to_federation, ->(record, content:, custom:) { captured = { record:, content:, custom: }; { "ok" => true } }) do
+    Federails::DataTransformer::Note.stub(:to_federation, ->(record, content:, name:, custom:) { captured = { record:, content:, name:, custom: }; { "ok" => true } }) do
       post.to_activitypub_object
     end
 
@@ -350,7 +489,7 @@ class PostTest < ActiveSupport::TestCase
     post = Post.create!(body: "기사 댓글", user: @user, article: @article)
 
     captured = nil
-    Federails::DataTransformer::Note.stub(:to_federation, ->(_record, content:, custom:) { captured = { content:, custom: }; { "ok" => true } }) do
+    Federails::DataTransformer::Note.stub(:to_federation, ->(_record, content:, name:, custom:) { captured = { content:, name:, custom: }; { "ok" => true } }) do
       post.to_activitypub_object
     end
 
@@ -431,5 +570,138 @@ class PostTest < ActiveSupport::TestCase
     result = Post.from_activitypub_object(hash)
 
     assert_equal "첫 번째 파일 · 두 번째 파일", result[:body]
+  end
+
+  test "to_activitypub_object는 장문을 요약과 제목과 원문 링크로 전달한다" do
+    post = posts(:longform_published)
+
+    captured = nil
+    Federails::DataTransformer::Note.stub(:to_federation, ->(record, content:, name:, custom:) { captured = { record:, content:, name:, custom: }; { "ok" => true } }) do
+      post.to_activitypub_object
+    end
+
+    assert_equal post, captured[:record]
+    assert_equal post.longform_summary, captured[:content]
+    assert_equal post.title, captured[:name]
+    assert_equal Rails.application.routes.url_helpers.post_url(post), captured[:custom]["url"]
+  end
+
+  test "to_activitypub_object의 실제 발행 Note에 장문 제목이 채워진다" do
+    post = Post.create!(
+      title: "실제 발행 장문",
+      body: "<p>실제 발행되는 장문 본문입니다.</p>",
+      user: @user,
+      post_type: :longform,
+      status: :published,
+      published_at: Time.current
+    )
+
+    note = post.to_activitypub_object
+
+    assert_equal post.title, note["name"]
+    assert_equal post.longform_summary, note["content"]
+    assert_equal Rails.application.routes.url_helpers.post_url(post), note["url"]
+  end
+
+  test "to_activitypub_object는 단문 본문 전체 발행을 유지한다" do
+    post = @root_post
+
+    captured = nil
+    Federails::DataTransformer::Note.stub(:to_federation, ->(_record, content:, name:, custom:) { captured = { content:, name:, custom: }; { "ok" => true } }) do
+      post.to_activitypub_object
+    end
+
+    assert_equal post.body, captured[:content]
+    assert_nil captured[:name]
+    assert_nil captured[:custom]["url"]
+    assert_nil captured[:custom]["name"]
+  end
+
+  # 초안은 원격에 객체가 없으므로 첫 발행은 Create로 전달해야 한다. publish!는
+  # save!가 일으키는 자동 Update를 억제하고 Create를 명시적으로 발행한다.
+  test "publish!는 초안 첫 발행 시 Federails Create 활동을 발행한다" do
+    post = posts(:longform_draft)
+
+    assert_difference -> { Federails::Activity.where(action: "Create", entity: post).count }, 1 do
+      assert_no_difference -> { Federails::Activity.where(action: "Update", entity: post).count } do
+        post.publish!
+      end
+    end
+  end
+
+  # 이미 발행된 글을 다시 publish!하면 원격에 객체가 존재하므로 일반 Update 경로를
+  # 유지한다(Create 억제는 draft→published 최초 전환에만 적용).
+  test "publish!는 이미 발행된 글에는 일반 Update 경로를 유지한다" do
+    post = posts(:longform_published)
+    post.body = "재발행 시 본문 변경"
+
+    assert_difference -> { Federails::Activity.where(action: "Update", entity: post).count }, 1 do
+      assert_no_difference -> { Federails::Activity.where(action: "Create", entity: post).count } do
+        post.publish!
+      end
+    end
+  end
+
+  # discard는 Discard::Model로 처리하고, after_discard에서 Delete를 발행한다.
+  test "발행 장문을 discard하면 Delete 활동을 발행한다" do
+    post = posts(:longform_published)
+
+    assert_difference -> { Federails::Activity.where(action: "Delete", entity: post).count }, 1 do
+      post.discard
+    end
+
+    assert_predicate post.reload, :discarded?
+  end
+
+  # soft_deleted_method: :discarded? 설정으로 삭제된 레코드는 federails_tombstoned?가
+  # 참이 되어, deleted_at 갱신이 일으키는 일반 Update 활동은 억제된다.
+  test "발행 장문을 discard하면 Update 활동은 발행하지 않는다" do
+    post = posts(:longform_published)
+
+    assert_no_difference -> { Federails::Activity.where(action: "Update", entity: post).count } do
+      post.discard
+    end
+  end
+
+  # 초안은 발행 전까지 로컬에만 머물러야 한다. should_federate?가 published?를
+  # 게이트하지 않으면 생성·자동저장마다 미발행 초안이 원격 팔로워에게 새어 나간다.
+  test "장문 초안은 생성 시 연합 활동을 발행하지 않는다" do
+    assert_no_difference -> { Federails::Activity.where(action: [ "Create", "Update" ]).count } do
+      @user.posts.create!(post_type: :longform, status: :draft, title: "비공개 초안", body: "")
+    end
+  end
+
+  test "장문 초안은 자동저장(update) 시 연합 활동을 발행하지 않는다" do
+    draft = posts(:longform_draft)
+
+    assert_no_difference -> { Federails::Activity.where(entity: draft).count } do
+      draft.update!(title: "자동 저장됨", body: "<p>본문</p>")
+    end
+  end
+
+  test "초안을 발행하면 그때 연합된다" do
+    draft = @user.posts.create!(post_type: :longform, status: :draft, title: "초안", body: "<p>본문</p>")
+
+    assert_difference -> { Federails::Activity.where(entity: draft).count }, 1 do
+      draft.publish!
+    end
+  end
+
+  # 소프트 삭제는 장문 전용. 인바운드 연합 Delete도 타입별로 분기한다.
+  test "인바운드 연합 삭제는 장문을 soft discard한다" do
+    post = posts(:longform_published)
+
+    post.run_callbacks(:on_federails_delete_requested)
+
+    assert_predicate post.reload, :discarded?
+    assert Post.exists?(post.id)
+  end
+
+  test "인바운드 연합 삭제는 댓글을 hard destroy한다" do
+    post = @comment_post
+
+    post.run_callbacks(:on_federails_delete_requested)
+
+    assert_not Post.exists?(post.id)
   end
 end


### PR DESCRIPTION
## 개요

큰 PR [#750](https://github.com/stadia/ruby-news/pull/750)에서 **DB/모델 계층만 분리**한 PR입니다. 먼저 데이터 모델을 리뷰·머지한 뒤, 컨트롤러·뷰·로케일·JS는 후속 PR에서 다룹니다.

## 변경 내용

### 마이그레이션
- **`add_longform_state_to_posts`** — `post_type`/`status`/`published_at` 컬럼 + 복합 인덱스(`type_status_created_at`, `user_type_status_created_at`) 추가. 기존 행 백필: `article_id` 유무로 `comment`/`short` 판별, `published_at`는 `created_at`으로 채움
- **`add_deleted_at_to_posts`** — Discard용 `deleted_at` 컬럼 + 인덱스

### 모델
- **`Post`**
  - `post_type`(`short`/`longform`/`comment`)·`status`(`draft`/`published`) enum
  - `Discard::Model` 도입(`deleted_at`)
  - `comments` 스코프를 `post_type: :comment` 기반으로 재정의, `visible`·`published_longform` 스코프 추가
  - `body`/`title` 검증을 draft/published에 맞춰 분기
  - 연합 시 longform은 `longform_summary`+`title`+`url`로 Note 구성
  - soft-delete 시 `Delete`/`Undo` 발행, inbound 페더레이션 Delete를 longform은 `discard`로(그 외 `destroy`) 처리
  - 사용처 없던 `comment?` 제거(메인 호출부 없음 확인)
- **`Posts::Longform` concern** — `publish!`(draft→published 최초 전환은 `Update` 억제 후 `Create` 명시 발행), draft/published predicate, `longform_summary`, 초안 본문 검증

## 검증
- 모델 테스트 81건 + **전체 스위트 747건 통과** (0 failures)
- 마이그레이션 백필로 `.comments` 스코프 의미 변경에도 기존 데이터 정합
- `comment?`·신규 스코프의 메인 외부 호출부 없음 확인 → main에 독립적으로 머지 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 게시물 상태 관리 기능 추가 (초안/발행됨)
  * 긴 형식 게시물 지원으로 콘텐츠 작성 옵션 확대
  * 게시물 소프트 삭제 기능 추가

* **Chores**
  * 데이터베이스 스키마 업데이트
  * 테스트 커버리지 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->