### PR TITLE
feat(article): 일본어 title을 title_ja에도 함께 저장

### DIFF
--- a/app/jobs/japanese_temp_job.rb
+++ b/app/jobs/japanese_temp_job.rb
@@ -8,7 +8,8 @@ class JapaneseTempJob < ApplicationJob
       return
     end
 
-    article = Article.kept.confirmed.where(title_ja: nil).order("created_at desc").limit(1).first
+    # 번역 완료 신호는 summary_key_ja (title_ja 는 일본어 원문 제목으로 미리 채워질 수 있음)
+    article = Article.kept.confirmed.where(summary_key_ja: nil).order("created_at desc").limit(1).first
     return if article.nil?
 
     article.discard! and return if article.title.nil?
@@ -21,7 +22,7 @@ class JapaneseTempJob < ApplicationJob
   def run_similar(article)
     similar_articles = Article.kept.confirmed.where.not(id: article.id).nearest_neighbors(:embedding, article.embedding, distance: "cosine").limit(4)
     similar_articles.each { |item|
-      next if item.title_ja.present?
+      next if item.summary_key_ja.present?
 
       item.title = Articles::Utils.truncate_title(item.title) if item.title.present? && item.title.size > 120
       ArticleAgentsService.new.send(:run_japanese, item)

--- a/app/madmin/resources/article_resource.rb
+++ b/app/madmin/resources/article_resource.rb
@@ -3,6 +3,7 @@ class ArticleResource < Madmin::Resource
   attribute :id, form: false
   attribute :title, new: false
   attribute :title_ko, index: true, new: false
+  attribute :title_ja, index: false, form: false
   attribute :slug, index: false, form: false
   attribute :deleted_at, index: false, form: false
   attribute :discarded?, index: true, form: false
@@ -20,6 +21,7 @@ class ArticleResource < Madmin::Resource
   attribute :is_posted, index: false, form: true
 
   attribute :summary_key, index: false, form: false
+  attribute :summary_key_ja, index: false, form: false
   attribute :summary_detail, index: false, form: false
   attribute :summary_introduction, index: false
   attribute :summary_body, index: false

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -116,6 +116,10 @@ class Article < ApplicationRecord
     end
   end
 
+  # title 이 일본어(가나 포함)인 경우 title_ja 에도 함께 저장한다.
+  # 판별 기준은 검색 스코프와 동일하게 JAPANESE_KANA_REGEX 를 재사용한다.
+  before_save :assign_japanese_title
+
   after_commit :clear_rss_cache, on: [ :create, :update, :destroy ]
 
   after_discard do
@@ -234,6 +238,14 @@ class Article < ApplicationRecord
 
   # ── Private Instance Methods ─────────────────────────────────────────
   private
+
+  #: () -> void
+  def assign_japanese_title
+    return if title.blank?
+    return unless title.match?(JAPANESE_KANA_REGEX)
+
+    self.title_ja = title
+  end
 
   #: () -> User?
   def bot_user

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -8,6 +8,11 @@ class Article < ApplicationRecord
   TITLE_BOUNDARY_MIN_RATIO = 0.6
   TITLE_BOUNDARY_PATTERN = /[\s[:punct:]、。，．！？；：·|｜-]/
 
+  # title 이 일본어인지 판별한다. 가나(かな) 또는 한자(漢字) 포함 여부로 본다.
+  # 한국어 제목에는 한자가 들어가지 않는다는 전제이며, 검색용 판별인
+  # JAPANESE_KANA_REGEX 와 달리 한자까지 일본어로 취급한다.
+  JAPANESE_TITLE_REGEX = /[\p{Hiragana}\p{Katakana}\p{Han}･-ﾟ]/
+
   # ── Extend ───────────────────────────────────────────────────────────
   extend FriendlyId
   friendly_id :slug, use: :slugged
@@ -116,8 +121,8 @@ class Article < ApplicationRecord
     end
   end
 
-  # title 이 일본어(가나 포함)인 경우 title_ja 에도 함께 저장한다.
-  # 판별 기준은 검색 스코프와 동일하게 JAPANESE_KANA_REGEX 를 재사용한다.
+  # title 이 일본어(가나 또는 한자 포함)인 경우 title_ja 에도 함께 저장한다.
+  # 판별 기준은 JAPANESE_TITLE_REGEX 를 사용한다.
   before_save :assign_japanese_title
 
   after_commit :clear_rss_cache, on: [ :create, :update, :destroy ]
@@ -242,7 +247,7 @@ class Article < ApplicationRecord
   #: () -> void
   def assign_japanese_title
     return if title.blank?
-    return unless title.match?(JAPANESE_KANA_REGEX)
+    return unless title.match?(JAPANESE_TITLE_REGEX)
 
     self.title_ja = title
   end

--- a/app/models/concerns/articles/localized_display.rb
+++ b/app/models/concerns/articles/localized_display.rb
@@ -44,13 +44,18 @@ module Articles
     end
 
     # Whether a genuine translation exists for the given locale (vs. falling back
-    # to the Korean source). :ja requires title_ja; :ko (base content) is always
-    # available. Used to noindex / exclude untranslated articles from the .jp
-    # locale so we never advertise Korean fallback content as Japanese.
+    # to the Korean source). :ja requires summary_key_ja; :ko (base content) is
+    # always available. Used to noindex / exclude untranslated articles from the
+    # .jp locale so we never advertise Korean fallback content as Japanese.
+    #
+    # summary_key_ja (not title_ja) is the completion signal: title_ja may be
+    # pre-filled from a Japanese source title before the article body/summary is
+    # translated, whereas summary_key_ja is only set by the Japanese translation
+    # pipeline (ArticleAgentsService#run_japanese / DeeplTranslationService).
     #: (Symbol?) -> bool
     def available_in?(locale = I18n.locale)
       case locale.to_sym
-      when :ja then title_ja.present?
+      when :ja then summary_key_ja.present?
       else          true
       end
     end

--- a/sig/generated/models/article.rbs
+++ b/sig/generated/models/article.rbs
@@ -70,6 +70,9 @@ class Article < ApplicationRecord
 
   private
 
+  # : () -> void
+  def assign_japanese_title: () -> void
+
   # : () -> User?
   def bot_user: () -> User?
 

--- a/sig/generated/models/article.rbs
+++ b/sig/generated/models/article.rbs
@@ -10,6 +10,11 @@ class Article < ApplicationRecord
 
   TITLE_BOUNDARY_PATTERN: ::Regexp
 
+  # title 이 일본어인지 판별한다. 가나(かな) 또는 한자(漢字) 포함 여부로 본다.
+  # 한국어 제목에는 한자가 들어가지 않는다는 전제이며, 검색용 판별인
+  # JAPANESE_KANA_REGEX 와 달리 한자까지 일본어로 취급한다.
+  JAPANESE_TITLE_REGEX: ::Regexp
+
   extend FriendlyId
 
   include PgSearch::Model

--- a/sig/generated/models/concerns/articles/localized_display.rbs
+++ b/sig/generated/models/concerns/articles/localized_display.rbs
@@ -23,9 +23,14 @@ module Articles
     def display_summary_body: (Symbol? locale) -> String?
 
     # Whether a genuine translation exists for the given locale (vs. falling back
-    # to the Korean source). :ja requires title_ja; :ko (base content) is always
-    # available. Used to noindex / exclude untranslated articles from the .jp
-    # locale so we never advertise Korean fallback content as Japanese.
+    # to the Korean source). :ja requires summary_key_ja; :ko (base content) is
+    # always available. Used to noindex / exclude untranslated articles from the
+    # .jp locale so we never advertise Korean fallback content as Japanese.
+    #
+    # summary_key_ja (not title_ja) is the completion signal: title_ja may be
+    # pre-filled from a Japanese source title before the article body/summary is
+    # translated, whereas summary_key_ja is only set by the Japanese translation
+    # pipeline (ArticleAgentsService#run_japanese / DeeplTranslationService).
     # : (Symbol?) -> bool
     def available_in?: (Symbol?) -> bool
 

--- a/test/jobs/japanese_temp_job_test.rb
+++ b/test/jobs/japanese_temp_job_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 class JapaneseTempJobTest < ActiveSupport::TestCase
   test "title이 nil인 article도 에러 없이 처리한다" do
     article = articles(:ruby_article)
-    article.update_columns(title: nil, title_ja: nil)
+    article.update_columns(title: nil, summary_key_ja: nil)
 
     fake_service = Object.new
     fake_service.define_singleton_method(:run_japanese) { |*| nil }
@@ -21,7 +21,7 @@ class JapaneseTempJobTest < ActiveSupport::TestCase
   end
 
   test "처리할 article이 없으면 조용히 종료한다" do
-    Article.kept.confirmed.where(title_ja: nil).update_all(title_ja: "dummy")
+    Article.kept.confirmed.where(summary_key_ja: nil).update_all(summary_key_ja: [ "dummy" ])
 
     assert_nothing_raised { JapaneseTempJob.perform_now }
   end

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -378,6 +378,36 @@ class ArticleTest < ActiveSupport::TestCase
     assert_nil article.deleted_at
   end
 
+  test "title이 일본어(가나 포함)이면 저장 시 title_ja에도 함께 저장해야 한다" do
+    article = Article.new(
+      title: "Rubyの新しい機能について",
+      url: "https://example.com/japanese-title-test",
+      origin_url: "https://example.com/japanese-title-test-origin",
+      user: @user
+    )
+
+    article.stub(:generate_metadata, nil) do
+      article.save!
+    end
+
+    assert_equal "Rubyの新しい機能について", article.title_ja
+  end
+
+  test "title이 일본어가 아니면 title_ja를 채우지 않아야 한다" do
+    article = Article.new(
+      title: "A regular English title",
+      url: "https://example.com/non-japanese-title-test",
+      origin_url: "https://example.com/non-japanese-title-test-origin",
+      user: @user
+    )
+
+    article.stub(:generate_metadata, nil) do
+      article.save!
+    end
+
+    assert_nil article.title_ja
+  end
+
   test "생성 전에 메타데이터를 생성해야 한다" do
     article = Article.new(
       title: "Test",

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -393,6 +393,21 @@ class ArticleTest < ActiveSupport::TestCase
     assert_equal "Rubyの新しい機能について", article.title_ja
   end
 
+  test "title이 한자(漢字)로만 이루어져도 일본어로 취급해 title_ja에 저장해야 한다" do
+    article = Article.new(
+      title: "日本語処理",
+      url: "https://example.com/kanji-only-title-test",
+      origin_url: "https://example.com/kanji-only-title-test-origin",
+      user: @user
+    )
+
+    article.stub(:generate_metadata, nil) do
+      article.save!
+    end
+
+    assert_equal "日本語処理", article.title_ja
+  end
+
   test "title이 일본어가 아니면 title_ja를 채우지 않아야 한다" do
     article = Article.new(
       title: "A regular English title",

--- a/test/models/concerns/localized_display_test.rb
+++ b/test/models/concerns/localized_display_test.rb
@@ -102,6 +102,28 @@ class LocalizedDisplayTest < ActiveSupport::TestCase
     assert_not @article.show_original_title?(locale: :ja)
   end
 
+  # ── available_in? ──────────────────────────────────────────────────
+
+  test "available_in? for ja is true when summary_key_ja present" do
+    @article.update_columns(summary_key_ja: [ "要約1" ])
+
+    assert @article.available_in?(:ja)
+  end
+
+  # 번역 완료 신호는 summary_key_ja 이므로, 일본어 원문 제목으로 title_ja 가
+  # 미리 채워졌더라도 실제 번역(summary_key_ja) 전에는 :ja 로 노출하지 않는다.
+  test "available_in? for ja is false when only title_ja present without summary_key_ja" do
+    @article.update_columns(title_ja: "日本語タイトル", summary_key_ja: nil)
+
+    assert_not @article.available_in?(:ja)
+  end
+
+  test "available_in? for ko is always true regardless of ja translation" do
+    @article.update_columns(summary_key_ja: nil)
+
+    assert @article.available_in?(:ko)
+  end
+
   # ── summary_key_preview ────────────────────────────────────────────
 
   test "summary_key_preview returns first item of array" do


### PR DESCRIPTION
## 개요
Article 저장 시 `title`이 일본어인 경우, 해당 title을 `title_ja` 컬럼에도 함께 저장합니다.

## 변경 내용
- `app/models/article.rb`: `before_save :assign_japanese_title` 콜백 및 private 메서드 추가
- `test/models/article_test.rb`: 일본어/비일본어 title 케이스 테스트 2개 추가
- `sig/generated/models/article.rbs`: RBS 시그니처 자동 생성

## 구현 세부
```ruby
before_save :assign_japanese_title

def assign_japanese_title
  return if title.blank?
  return unless title.match?(JAPANESE_KANA_REGEX)

  self.title_ja = title
end
```

- `title_ja` 컬럼은 이미 존재하여 마이그레이션 불필요
- 일본어 판별은 기존 `full_text_search_for` 스코프와 동일하게 `JAPANESE_KANA_REGEX`(히라가나/가타카나) 재사용

## 알려진 한계
가나 없이 한자(漢字)로만 구성된 일본어 제목은 감지되지 않습니다. 한자는 한중일 구분이 모호해 프로젝트 기존 컨벤션(가나 기준)을 따랐습니다.

## 테스트
`bin/rails test test/models/article_test.rb` → 71 runs, 217 assertions, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 저장 시 제목이 일본어(히라가나/가타카나 및 한자 포함)로 판별되면 일본어 제목 `title_ja`가 함께 보존되도록 개선했습니다.
  * 일본어가 아닌 제목은 `title_ja`가 비지 않도록 유지됩니다.
* **New Features**
  * 관리자 화면에서 `title_ja`, `summary_key_ja` 항목을 볼 수 있게 했습니다.
* **Tests**
  * 일본어 제목 저장/미저장 동작을 검증하는 테스트 3개를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->