### PR TITLE
fix(sitemap): 도메인별 자기 완결 사이트맵으로 분리

### DIFF
--- a/app/functions/sitemap_builder.rb
+++ b/app/functions/sitemap_builder.rb
@@ -12,6 +12,12 @@ module SitemapBuilder
   # 날짜"로 사이트맵을 거부한다. Rails 등장(2004) 이전 floor로 사용한다.
   MIN_LASTMOD = Time.zone.local(2004, 1, 1)
 
+  # 링크를 5,000개마다 디스크로 flush하고 버퍼를 비운다. 기본값(50,000)이면
+  # 전체 링크(<50k)를 한 버퍼에 통째로 물고 있다가 flush해 순간 메모리 peak가
+  # 컸다. 이 빌드는 장수명 solid_queue 워커 안에서 돌므로 그 스파이크가 워커
+  # 컨테이너 OOM을 유발했다. 값이 낮을수록 peak↓·사이트맵 파일수↑(둘 다 무해).
+  MAX_SITEMAP_LINKS = 5_000
+
   class << self
     include Rails.application.routes.url_helpers
 
@@ -39,53 +45,61 @@ module SitemapBuilder
       candidate >= MIN_LASTMOD && candidate <= Time.current
     end
 
+    # 도메인별로 자기 완결적인 사이트맵을 생성한다. 로케일마다 별도 LinkSet을
+    # 만들어 인덱스·자식 사이트맵·<loc>가 모두 자기 호스트(ko=.dev, ja=.jp)에
+    # 속하도록 한다. 이전에는 단일 LinkSet(default_host 하드코딩)이 양 도메인에
+    # 공유돼, .jp 인덱스가 .dev 자식을 가리키는 크로스도메인 참조가 생겼고
+    # GSC가 사이트맵 귀속을 하지 못했다(참조 페이지가 반대 도메인으로 잡힘).
+    # Sitemaps.org 프로토콜의 "한 사이트맵의 URL은 단일 호스트" 원칙도 준수한다.
     #: () -> void
     def build
-      SitemapGenerator::Sitemap.default_host  = "https://ruby-news.dev"
-      SitemapGenerator::Sitemap.sitemaps_path = "sitemaps/"
-      SitemapGenerator::Sitemap.compress      = true
-      SitemapGenerator::Sitemap.include_root  = false
-      # 링크를 5,000개마다 디스크로 flush하고 버퍼를 비운다. 기본값(50,000)이면
-      # 전체 링크(<50k)를 한 버퍼에 통째로 물고 있다가 flush해 순간 메모리 peak가
-      # 컸다. 이 빌드는 장수명 solid_queue 워커 안에서 돌므로 그 스파이크가 워커
-      # 컨테이너 OOM을 유발했다. 값이 낮을수록 peak↓·사이트맵 파일수↑(둘 다 무해).
-      SitemapGenerator::Sitemap.max_sitemap_links = 5_000
+      HREFLANG_HOSTS.each { |locale, host| build_locale(locale, host) }
+    end
 
-      SitemapGenerator::Sitemap.create do
-        # 각 로케일 호스트(ko=.dev, ja=.jp)를 개별 <url> 블록으로 등재한다.
-        # 각 블록은 자신의 <loc> 1개 + ko/ja hreflang alternates를 모두 포함하는
-        # Google 권장 다국어 사이트맵 구조다. ko·ja가 각각 색인 대상이므로
-        # GSC 발견 페이지 수가 2배가 되는 것은 정상이다.
-        # 목록 페이지 lastmod: 맨 날짜(Date)는 타임존이 없어 파서가 UTC 자정으로 해석 → KST 오늘이 UTC 기준 미래로 보인다. 오프셋이 붙는 Time을 사용.
-        index_lastmod = Time.current.iso8601
-        SitemapBuilder::HREFLANG_HOSTS.each_value do |host|
-          add root_path, host: host,
-              lastmod: index_lastmod,
-              alternates: SitemapBuilder.alternates_for(root_path)
-          add articles_path, host: host,
-              lastmod: index_lastmod,
-              alternates: SitemapBuilder.alternates_for(articles_path)
-          add others_path, host: host,
-              lastmod: index_lastmod,
-              alternates: SitemapBuilder.alternates_for(others_path)
-        end
+    # 단일 로케일/호스트에 대한 자기 완결 사이트맵(인덱스 + 샤드)을 생성한다.
+    # 출력: public/sitemaps/<locale>/sitemap.xml.gz (+ sitemap1..N.xml.gz)
+    #: (String, String) -> void
+    def build_locale(locale, host)
+      link_set = SitemapGenerator::LinkSet.new(
+        default_host: host,
+        sitemaps_path: "sitemaps/#{locale}/",
+        include_root: false,
+        compress: true,
+        max_sitemap_links: MAX_SITEMAP_LINKS
+      )
 
-        Article.kept
-               .confirmed
-               .find_in_batches(batch_size: 500) do |batch|
-          batch.each do |article|
-            path = article_path(article.slug)
-            lastmod = SitemapBuilder.lastmod_for(article)
-            # 번역이 존재하는 로케일 호스트만 등재한다. 일본어 번역이 없는
-            # 기사는 .jp(<loc>·hreflang alternate) 에서 제외 → 한국어 폴백을
-            # 일본어로 색인시키지 않는다. 번역되면 다음 빌드에서 자동 포함.
-            available = SitemapBuilder::HREFLANG_HOSTS.keys.select { |loc| article.available_in?(loc) }
-            alternates = SitemapBuilder.alternates_for(path, available)
-            SitemapBuilder::HREFLANG_HOSTS.each do |locale, host|
-              next unless article.available_in?(locale)
-              add path, host: host, lastmod: lastmod, alternates: alternates
-            end
-          end
+      # create 블록은 Interpreter 컨텍스트에서 instance_eval 되므로 self가 DSL
+      # (add 응답)이 된다. 실제 링크 등재 로직은 populate 로 분리해 테스트를
+      # 용이하게 하고, locale/host 는 클로저로 캡처된다.
+      link_set.create { SitemapBuilder.populate(self, locale, host) }
+    end
+
+    # 주어진 로케일/호스트의 모든 URL을 DSL(add 응답 객체)에 등재한다.
+    # 각 <url>은 자기 호스트 <loc> 1개 + ko/ja hreflang alternates를 포함하는
+    # Google 권장 다국어 구조다(상호 참조 유지).
+    #: (untyped, String, String) -> void
+    def populate(dsl, locale, host)
+      # 목록 페이지 lastmod: 맨 날짜(Date)는 타임존이 없어 파서가 UTC 자정으로
+      # 해석 → KST 오늘이 UTC 기준 미래로 보인다. 오프셋이 붙는 Time을 사용.
+      index_lastmod = Time.current.iso8601
+      [ root_path, articles_path, others_path ].each do |path|
+        dsl.add path, host: host, lastmod: index_lastmod, alternates: alternates_for(path)
+      end
+
+      Article.kept
+             .confirmed
+             .find_in_batches(batch_size: 500) do |batch|
+        batch.each do |article|
+          # 이 사이트맵의 로케일 번역이 없는 기사는 제외한다. 일본어 번역이
+          # 없는 기사는 .jp(ja) 사이트맵의 <loc>·alternate 에서 빠져 한국어
+          # 폴백을 일본어로 색인시키지 않는다. 번역되면 다음 빌드에서 자동 포함.
+          next unless article.available_in?(locale)
+
+          path = article_path(article.slug)
+          available = HREFLANG_HOSTS.keys.select { |loc| article.available_in?(loc) }
+          dsl.add path, host: host,
+                  lastmod: lastmod_for(article),
+                  alternates: alternates_for(path, available)
         end
       end
     end

--- a/app/functions/sitemap_builder.rb
+++ b/app/functions/sitemap_builder.rb
@@ -18,6 +18,11 @@ module SitemapBuilder
   # 컨테이너 OOM을 유발했다. 값이 낮을수록 peak↓·사이트맵 파일수↑(둘 다 무해).
   MAX_SITEMAP_LINKS = 5_000
 
+  # 사이트맵에 등재할 기사 1건의 경량 표현. DB를 한 번만 순회해 이 값들을 모아
+  # ko/ja 빌드가 공유한다(AR 객체를 로케일마다 다시 읽지 않는다).
+  #   available: 번역이 존재하는 로케일 키 배열(예: ["ko", "ja"] 또는 ["ko"])
+  Entry = Data.define(:path, :lastmod, :available, :alternates)
+
   class << self
     include Rails.application.routes.url_helpers
 
@@ -53,13 +58,45 @@ module SitemapBuilder
     # Sitemaps.org 프로토콜의 "한 사이트맵의 URL은 단일 호스트" 원칙도 준수한다.
     #: () -> void
     def build
-      HREFLANG_HOSTS.each { |locale, host| build_locale(locale, host) }
+      # 기사는 DB를 한 번만 순회해 수집하고, 그 배열을 ko/ja 빌드가 공유한다.
+      # (로케일마다 기사 테이블을 전체 스캔하던 것을 1회로.)
+      entries = collect_article_entries
+      HREFLANG_HOSTS.each { |locale, host| build_locale(locale, host, entries) }
+    end
+
+    # 사이트맵에 등재할 기사를 DB에서 한 번만 순회해 경량 Entry 배열로 수집한다.
+    # AR 객체가 아니라 값(경로·lastmod·가용 로케일·alternates)만 담으므로 메모리
+    # 부담이 작다. alternates 는 로케일과 무관(path+available에만 의존)하므로 여기서
+    # 한 번만 계산해 양 로케일이 재사용한다.
+    #: () -> Array[Entry]
+    def collect_article_entries
+      entries = []
+      Article.kept
+             .confirmed
+             .find_in_batches(batch_size: 500) do |batch|
+        batch.each do |article|
+          # 번역이 존재하는 로케일만 등재 대상. 일본어 번역이 없는 기사는
+          # .jp(ja) 사이트맵의 <loc>·alternate 에서 빠져 한국어 폴백을 일본어로
+          # 색인시키지 않는다. 번역되면 다음 빌드에서 자동 포함.
+          available = HREFLANG_HOSTS.keys.select { |loc| article.available_in?(loc) }
+          next if available.empty?
+
+          path = article_path(article.slug)
+          entries << Entry.new(
+            path: path,
+            lastmod: lastmod_for(article),
+            available: available,
+            alternates: alternates_for(path, available)
+          )
+        end
+      end
+      entries
     end
 
     # 단일 로케일/호스트에 대한 자기 완결 사이트맵(인덱스 + 샤드)을 생성한다.
     # 출력: public/sitemaps/<locale>/sitemap.xml.gz (+ sitemap1..N.xml.gz)
-    #: (String, String) -> void
-    def build_locale(locale, host)
+    #: (String, String, Array[Entry]) -> void
+    def build_locale(locale, host, entries)
       link_set = SitemapGenerator::LinkSet.new(
         default_host: host,
         sitemaps_path: "sitemaps/#{locale}/",
@@ -70,15 +107,15 @@ module SitemapBuilder
 
       # create 블록은 Interpreter 컨텍스트에서 instance_eval 되므로 self가 DSL
       # (add 응답)이 된다. 실제 링크 등재 로직은 populate 로 분리해 테스트를
-      # 용이하게 하고, locale/host 는 클로저로 캡처된다.
-      link_set.create { SitemapBuilder.populate(self, locale, host) }
+      # 용이하게 하고, locale/host/entries 는 클로저로 캡처된다.
+      link_set.create { SitemapBuilder.populate(self, locale, host, entries) }
     end
 
-    # 주어진 로케일/호스트의 모든 URL을 DSL(add 응답 객체)에 등재한다.
-    # 각 <url>은 자기 호스트 <loc> 1개 + ko/ja hreflang alternates를 포함하는
-    # Google 권장 다국어 구조다(상호 참조 유지).
-    #: (untyped, String, String) -> void
-    def populate(dsl, locale, host)
+    # 주어진 로케일/호스트의 URL을 DSL(add 응답 객체)에 등재한다. 정적 페이지와,
+    # 미리 수집된 기사 Entry 중 해당 로케일 번역이 있는 것만 자기 호스트 <loc>로
+    # 넣고 각 <url>에 ko/ja hreflang alternates를 붙인다(상호 참조 유지).
+    #: (untyped, String, String, Array[Entry]) -> void
+    def populate(dsl, locale, host, entries)
       # 목록 페이지 lastmod: 맨 날짜(Date)는 타임존이 없어 파서가 UTC 자정으로
       # 해석 → KST 오늘이 UTC 기준 미래로 보인다. 오프셋이 붙는 Time을 사용.
       index_lastmod = Time.current.iso8601
@@ -86,21 +123,10 @@ module SitemapBuilder
         dsl.add path, host: host, lastmod: index_lastmod, alternates: alternates_for(path)
       end
 
-      Article.kept
-             .confirmed
-             .find_in_batches(batch_size: 500) do |batch|
-        batch.each do |article|
-          # 이 사이트맵의 로케일 번역이 없는 기사는 제외한다. 일본어 번역이
-          # 없는 기사는 .jp(ja) 사이트맵의 <loc>·alternate 에서 빠져 한국어
-          # 폴백을 일본어로 색인시키지 않는다. 번역되면 다음 빌드에서 자동 포함.
-          next unless article.available_in?(locale)
+      entries.each do |entry|
+        next unless entry.available.include?(locale)
 
-          path = article_path(article.slug)
-          available = HREFLANG_HOSTS.keys.select { |loc| article.available_in?(loc) }
-          dsl.add path, host: host,
-                  lastmod: lastmod_for(article),
-                  alternates: alternates_for(path, available)
-        end
+        dsl.add entry.path, host: host, lastmod: entry.lastmod, alternates: entry.alternates
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,9 +75,12 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "home#index"
 
-  # 관용 경로 /sitemap.xml → 실제 사이트맵 인덱스로 301 리다이렉트
-  # (실제 파일은 SitemapBuilder가 public/sitemaps/ 에 생성)
-  get "sitemap.xml", to: redirect("/sitemaps/sitemap.xml.gz", status: 301)
+  # 관용 경로 /sitemap.xml → 요청 호스트의 로케일별 사이트맵 인덱스로 301 리다이렉트.
+  # 사이트맵은 도메인별로 분리 생성되므로(.dev=ko, .jp=ja) 호스트에 맞는 경로로 보낸다.
+  # (실제 파일은 SitemapBuilder가 public/sitemaps/<locale>/ 에 생성)
+  get "sitemap.xml", to: redirect(status: 301) { |_params, request|
+    "/sitemaps/#{Hosts.locale_for_host(request.host)}/sitemap.xml.gz"
+  }
 
   # llms.txt 는 로케일(호스트)별로 다른 본문을 서빙해야 하므로 동적 라우트로 처리한다.
   # (기존 정적 public/llms.txt 는 삭제됨 — 정적 파일이 라우트보다 우선 매칭되기 때문)

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,9 +1,11 @@
 # config/sitemap.rb
 # 실행: bundle exec rake sitemap:refresh:no_ping
 #
-# 출력 파일:
-#   public/sitemaps/sitemap.xml.gz        <- 사이트맵 인덱스
-#   public/sitemaps/sitemap1..N.xml.gz    <- URL (max_sitemap_links=5,000마다 분할)
+# 출력 파일 (도메인별 자기 완결 사이트맵):
+#   public/sitemaps/ko/sitemap.xml.gz      <- .dev(ko) 인덱스
+#   public/sitemaps/ko/sitemap1..N.xml.gz  <- .dev URL (max_sitemap_links=5,000마다 분할)
+#   public/sitemaps/ja/sitemap.xml.gz      <- .jp(ja) 인덱스
+#   public/sitemaps/ja/sitemap1..N.xml.gz  <- .jp URL
 #
 # ping 없음: Google은 2023년 말 sitemap ping 엔드포인트를 공식 폐지.
 # 사이트맵 등록은 Google Search Console에서 직접 수행한다.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -47,5 +47,5 @@ Disallow: /
 User-agent: ClaudeBot
 Disallow: /
 
-Sitemap: https://ruby-news.dev/sitemaps/sitemap.xml.gz
-Sitemap: https://ruby-news.jp/sitemaps/sitemap.xml.gz
+Sitemap: https://ruby-news.dev/sitemaps/ko/sitemap.xml.gz
+Sitemap: https://ruby-news.jp/sitemaps/ja/sitemap.xml.gz

--- a/sig/generated/functions/sitemap_builder.rbs
+++ b/sig/generated/functions/sitemap_builder.rbs
@@ -17,6 +17,26 @@ module SitemapBuilder
   # 컨테이너 OOM을 유발했다. 값이 낮을수록 peak↓·사이트맵 파일수↑(둘 다 무해).
   MAX_SITEMAP_LINKS: ::Integer
 
+  # 사이트맵에 등재할 기사 1건의 경량 표현. DB를 한 번만 순회해 이 값들을 모아
+  # ko/ja 빌드가 공유한다(AR 객체를 로케일마다 다시 읽지 않는다).
+  #   available: 번역이 존재하는 로케일 키 배열(예: ["ko", "ja"] 또는 ["ko"])
+  class Entry < Data
+    attr_reader path(): untyped
+
+    attr_reader lastmod(): untyped
+
+    attr_reader available(): untyped
+
+    attr_reader alternates(): untyped
+
+    def self.new: (untyped path, untyped lastmod, untyped available, untyped alternates) -> instance
+                | (path: untyped, lastmod: untyped, available: untyped, alternates: untyped) -> instance
+
+    def self.members: () -> [ :path, :lastmod, :available, :alternates ]
+
+    def members: () -> [ :path, :lastmod, :available, :alternates ]
+  end
+
   # : (String, ?Array[String]) -> Array[Hash[Symbol, String]]
   def self.alternates_for: (String, ?Array[String]) -> Array[Hash[Symbol, String]]
 
@@ -38,14 +58,21 @@ module SitemapBuilder
   # : () -> void
   def self.build: () -> void
 
+  # 사이트맵에 등재할 기사를 DB에서 한 번만 순회해 경량 Entry 배열로 수집한다.
+  # AR 객체가 아니라 값(경로·lastmod·가용 로케일·alternates)만 담으므로 메모리
+  # 부담이 작다. alternates 는 로케일과 무관(path+available에만 의존)하므로 여기서
+  # 한 번만 계산해 양 로케일이 재사용한다.
+  # : () -> Array[Entry]
+  def self.collect_article_entries: () -> Array[Entry]
+
   # 단일 로케일/호스트에 대한 자기 완결 사이트맵(인덱스 + 샤드)을 생성한다.
   # 출력: public/sitemaps/<locale>/sitemap.xml.gz (+ sitemap1..N.xml.gz)
-  # : (String, String) -> void
-  def self.build_locale: (String, String) -> void
+  # : (String, String, Array[Entry]) -> void
+  def self.build_locale: (String, String, Array[Entry]) -> void
 
-  # 주어진 로케일/호스트의 모든 URL을 DSL(add 응답 객체)에 등재한다.
-  # 각 <url>은 자기 호스트 <loc> 1개 + ko/ja hreflang alternates를 포함하는
-  # Google 권장 다국어 구조다(상호 참조 유지).
-  # : (untyped, String, String) -> void
-  def self.populate: (untyped, String, String) -> void
+  # 주어진 로케일/호스트의 URL을 DSL(add 응답 객체)에 등재한다. 정적 페이지와,
+  # 미리 수집된 기사 Entry 중 해당 로케일 번역이 있는 것만 자기 호스트 <loc>로
+  # 넣고 각 <url>에 ko/ja hreflang alternates를 붙인다(상호 참조 유지).
+  # : (untyped, String, String, Array[Entry]) -> void
+  def self.populate: (untyped, String, String, Array[Entry]) -> void
 end

--- a/sig/generated/functions/sitemap_builder.rbs
+++ b/sig/generated/functions/sitemap_builder.rbs
@@ -11,6 +11,12 @@ module SitemapBuilder
   # 날짜"로 사이트맵을 거부한다. Rails 등장(2004) 이전 floor로 사용한다.
   MIN_LASTMOD: untyped
 
+  # 링크를 5,000개마다 디스크로 flush하고 버퍼를 비운다. 기본값(50,000)이면
+  # 전체 링크(<50k)를 한 버퍼에 통째로 물고 있다가 flush해 순간 메모리 peak가
+  # 컸다. 이 빌드는 장수명 solid_queue 워커 안에서 돌므로 그 스파이크가 워커
+  # 컨테이너 OOM을 유발했다. 값이 낮을수록 peak↓·사이트맵 파일수↑(둘 다 무해).
+  MAX_SITEMAP_LINKS: ::Integer
+
   # : (String, ?Array[String]) -> Array[Hash[Symbol, String]]
   def self.alternates_for: (String, ?Array[String]) -> Array[Hash[Symbol, String]]
 
@@ -23,6 +29,23 @@ module SitemapBuilder
   # : (Time) -> bool
   def self.realistic_lastmod?: (Time) -> bool
 
+  # 도메인별로 자기 완결적인 사이트맵을 생성한다. 로케일마다 별도 LinkSet을
+  # 만들어 인덱스·자식 사이트맵·<loc>가 모두 자기 호스트(ko=.dev, ja=.jp)에
+  # 속하도록 한다. 이전에는 단일 LinkSet(default_host 하드코딩)이 양 도메인에
+  # 공유돼, .jp 인덱스가 .dev 자식을 가리키는 크로스도메인 참조가 생겼고
+  # GSC가 사이트맵 귀속을 하지 못했다(참조 페이지가 반대 도메인으로 잡힘).
+  # Sitemaps.org 프로토콜의 "한 사이트맵의 URL은 단일 호스트" 원칙도 준수한다.
   # : () -> void
   def self.build: () -> void
+
+  # 단일 로케일/호스트에 대한 자기 완결 사이트맵(인덱스 + 샤드)을 생성한다.
+  # 출력: public/sitemaps/<locale>/sitemap.xml.gz (+ sitemap1..N.xml.gz)
+  # : (String, String) -> void
+  def self.build_locale: (String, String) -> void
+
+  # 주어진 로케일/호스트의 모든 URL을 DSL(add 응답 객체)에 등재한다.
+  # 각 <url>은 자기 호스트 <loc> 1개 + ko/ja hreflang alternates를 포함하는
+  # Google 권장 다국어 구조다(상호 참조 유지).
+  # : (untyped, String, String) -> void
+  def self.populate: (untyped, String, String) -> void
 end

--- a/test/functions/sitemap_builder_test.rb
+++ b/test/functions/sitemap_builder_test.rb
@@ -3,73 +3,66 @@
 require "test_helper"
 
 class SitemapBuilderTest < ActiveSupport::TestCase
-  test "call은 SitemapGenerator를 설정하고 create를 호출한다" do
-    create_called = false
+  # add(path, options) 호출을 기록하는 테스트용 DSL 스텁.
+  class FakeDsl
+    attr_reader :calls
 
-    SitemapGenerator::Sitemap.stub(:create, ->(&_block) {
-      create_called = true
-
-      assert_equal "https://ruby-news.dev", SitemapGenerator::Sitemap.default_host
-      assert_equal "sitemaps/", SitemapGenerator::Sitemap.sitemaps_path
-      assert SitemapGenerator::Sitemap.compress
-    }) do
-      SitemapBuilder.build
+    def initialize
+      @calls = []
     end
 
-    assert create_called, "SitemapGenerator::Sitemap.create가 호출되어야 합니다"
-  end
-
-  test "홈 URL은 ko와 ja URL 노드와 hreflang alternates를 모두 가진다" do
-    add_calls = []
-    sitemap_dsl = Class.new do
-      include Rails.application.routes.url_helpers
-
-      define_method(:add) do |path, options|
-        add_calls << [ path, options ]
-      end
-    end.new
-
-    SitemapGenerator::Sitemap.stub(:create, ->(&block) { sitemap_dsl.instance_eval(&block) }) do
-      SitemapBuilder.build
-    end
-
-    root_calls = add_calls.select { |path, _options| path == "/" }
-
-    assert_equal [ "https://ruby-news.dev", "https://ruby-news.jp" ], root_calls.map { |_path, options| options.fetch(:host) }
-    root_calls.each do |_path, options|
-      assert_equal [
-        { href: "https://ruby-news.dev", lang: "ko" },
-        { href: "https://ruby-news.jp", lang: "ja" }
-      ], options.fetch(:alternates)
+    def add(path, options)
+      @calls << [ path, options ]
     end
   end
 
-  test "call 메서드는 블록을 create에 전달한다" do
-    block_passed = false
+  test "build는 도메인별로 자기 완결 LinkSet을 생성한다(.dev=ko, .jp=ja)" do
+    captured = []
+    fake_link_set = Object.new
+    def fake_link_set.create(*); end # 블록 미실행: DB/인터프리터 우회
 
-    SitemapGenerator::Sitemap.stub(:create, ->(&block) {
-      block_passed = block.present?
-    }) do
+    SitemapGenerator::LinkSet.stub(:new, ->(**opts) { captured << opts; fake_link_set }) do
       SitemapBuilder.build
     end
 
-    assert block_passed, "create에 블록이 전달되어야 합니다"
+    assert_equal 2, captured.size, "로케일(ko/ja)마다 LinkSet이 하나씩 생성되어야 한다"
+
+    ko, ja = captured
+
+    assert_equal "https://ruby-news.dev", ko[:default_host]
+    assert_equal "sitemaps/ko/", ko[:sitemaps_path]
+    assert_equal "https://ruby-news.jp", ja[:default_host]
+    assert_equal "sitemaps/ja/", ja[:sitemaps_path]
+
+    captured.each do |opts|
+      assert_equal SitemapBuilder::MAX_SITEMAP_LINKS, opts[:max_sitemap_links]
+      assert_equal 5_000, opts[:max_sitemap_links]
+      assert opts[:compress]
+      refute opts[:include_root]
+    end
   end
 
-  test "기본 호스트는 ruby-news.dev이다" do
-    captured_host = nil
+  test "populate(ko)는 정적 페이지를 .dev 호스트로 등재하고 hreflang alternates를 붙인다" do
+    dsl = FakeDsl.new
+    SitemapBuilder.populate(dsl, "ko", "https://ruby-news.dev")
 
-    SitemapGenerator::Sitemap.stub(:default_host=, ->(v) { captured_host = v }) do
-      SitemapGenerator::Sitemap.stub(:sitemaps_path=, nil) do
-        SitemapGenerator::Sitemap.stub(:compress=, nil) do
-          SitemapGenerator::Sitemap.stub(:create, ->(&_) { }) do
-            SitemapBuilder.build
-          end
-        end
-      end
-    end
+    root = dsl.calls.find { |path, _options| path == "/" }
 
-    assert_equal "https://ruby-news.dev", captured_host
+    assert root, "홈 URL이 등재되어야 한다"
+    assert_equal "https://ruby-news.dev", root[1].fetch(:host)
+    assert_equal [
+      { href: "https://ruby-news.dev", lang: "ko" },
+      { href: "https://ruby-news.jp", lang: "ja" }
+    ], root[1].fetch(:alternates)
+  end
+
+  test "populate(ja)의 <loc>는 .jp 호스트만 가진다" do
+    dsl = FakeDsl.new
+    SitemapBuilder.populate(dsl, "ja", "https://ruby-news.jp")
+
+    hosts = dsl.calls.map { |_path, options| options.fetch(:host) }.uniq
+
+    assert_equal [ "https://ruby-news.jp" ], hosts, "ja 사이트맵의 <loc>는 .jp 호스트만 가진다"
   end
 
   test "보조 도메인은 hreflang alternates로 포함한다" do
@@ -104,57 +97,5 @@ class SitemapBuilderTest < ActiveSupport::TestCase
     )
 
     assert_equal "2026-01-02T10:00:00+09:00", SitemapBuilder.lastmod_for(article)
-  end
-
-  test "사이트맵 경로는 sitemaps/이다" do
-    captured_path = nil
-
-    SitemapGenerator::Sitemap.stub(:default_host=, nil) do
-      SitemapGenerator::Sitemap.stub(:sitemaps_path=, ->(v) { captured_path = v }) do
-        SitemapGenerator::Sitemap.stub(:compress=, nil) do
-          SitemapGenerator::Sitemap.stub(:create, ->(&_) { }) do
-            SitemapBuilder.build
-          end
-        end
-      end
-    end
-
-    assert_equal "sitemaps/", captured_path
-  end
-
-  test "compress는 true로 설정된다" do
-    compress_set = false
-
-    SitemapGenerator::Sitemap.stub(:default_host=, nil) do
-      SitemapGenerator::Sitemap.stub(:sitemaps_path=, nil) do
-        SitemapGenerator::Sitemap.stub(:compress=, ->(v) { compress_set = v }) do
-          SitemapGenerator::Sitemap.stub(:create, ->(&_) { }) do
-            SitemapBuilder.build
-          end
-        end
-      end
-    end
-
-    assert compress_set
-  end
-
-  # max_sitemap_links를 낮춰 gem이 더 자주 디스크로 flush하게 하면, 메모리에 동시에
-  # 쥐는 Link 버퍼가 줄어 사이트맵 빌드의 순간 메모리 peak가 내려간다.
-  test "max_sitemap_links를 5,000으로 낮춘다" do
-    captured = nil
-
-    SitemapGenerator::Sitemap.stub(:default_host=, nil) do
-      SitemapGenerator::Sitemap.stub(:sitemaps_path=, nil) do
-        SitemapGenerator::Sitemap.stub(:compress=, nil) do
-          SitemapGenerator::Sitemap.stub(:max_sitemap_links=, ->(v) { captured = v }) do
-            SitemapGenerator::Sitemap.stub(:create, ->(&_) { }) do
-              SitemapBuilder.build
-            end
-          end
-        end
-      end
-    end
-
-    assert_equal 5_000, captured
   end
 end

--- a/test/functions/sitemap_builder_test.rb
+++ b/test/functions/sitemap_builder_test.rb
@@ -36,7 +36,6 @@ class SitemapBuilderTest < ActiveSupport::TestCase
 
     captured.each do |opts|
       assert_equal SitemapBuilder::MAX_SITEMAP_LINKS, opts[:max_sitemap_links]
-      assert_equal 5_000, opts[:max_sitemap_links]
       assert opts[:compress]
       refute opts[:include_root]
     end
@@ -44,7 +43,7 @@ class SitemapBuilderTest < ActiveSupport::TestCase
 
   test "populate(ko)는 정적 페이지를 .dev 호스트로 등재하고 hreflang alternates를 붙인다" do
     dsl = FakeDsl.new
-    SitemapBuilder.populate(dsl, "ko", "https://ruby-news.dev")
+    SitemapBuilder.populate(dsl, "ko", "https://ruby-news.dev", [])
 
     root = dsl.calls.find { |path, _options| path == "/" }
 
@@ -58,11 +57,30 @@ class SitemapBuilderTest < ActiveSupport::TestCase
 
   test "populate(ja)의 <loc>는 .jp 호스트만 가진다" do
     dsl = FakeDsl.new
-    SitemapBuilder.populate(dsl, "ja", "https://ruby-news.jp")
+    SitemapBuilder.populate(dsl, "ja", "https://ruby-news.jp", [])
 
     hosts = dsl.calls.map { |_path, options| options.fetch(:host) }.uniq
 
     assert_equal [ "https://ruby-news.jp" ], hosts, "ja 사이트맵의 <loc>는 .jp 호스트만 가진다"
+  end
+
+  test "populate는 해당 로케일 번역이 있는 Entry만 등재한다" do
+    ko_only = SitemapBuilder::Entry.new(
+      path: "/articles/x",
+      lastmod: "2026-01-01T00:00:00+09:00",
+      available: [ "ko" ],
+      alternates: [ { href: "https://ruby-news.dev/articles/x", lang: "ko" } ]
+    )
+
+    ko_dsl = FakeDsl.new
+    SitemapBuilder.populate(ko_dsl, "ko", "https://ruby-news.dev", [ ko_only ])
+
+    assert_includes ko_dsl.calls.map(&:first), "/articles/x", "ko 번역이 있으면 ko 사이트맵에 등재"
+
+    ja_dsl = FakeDsl.new
+    SitemapBuilder.populate(ja_dsl, "ja", "https://ruby-news.jp", [ ko_only ])
+
+    refute_includes ja_dsl.calls.map(&:first), "/articles/x", "ja 번역이 없으면 ja 사이트맵에서 제외"
   end
 
   test "보조 도메인은 hreflang alternates로 포함한다" do


### PR DESCRIPTION
## 배경

GSC URL 검사에서 `.dev` 기사가 **`.jp` 사이트맵**(`ruby-news.jp/sitemaps/sitemap.xml.gz`)을 통해 발견되고, `.dev` 속성에서는 "감지된 참조 사이트맵 없음"으로 나오는 문제가 있었다.

**원인**: 단일 `SitemapGenerator::Sitemap` 싱글턴이 `default_host = ruby-news.dev`로 하드코딩되어 사이트맵 파일 한 벌이 양 도메인에 공유됨. 그 결과 `.jp` 인덱스가 자식 사이트맵을 `.dev` 호스트로 가리키는 **크로스도메인 참조**가 발생 → GSC가 사이트맵 귀속을 하지 못함. Sitemaps.org의 "한 사이트맵의 URL은 단일 호스트" 원칙과 "인덱스↔자식 동일 호스트" 규칙도 위반.

## 변경

로케일별 `LinkSet` 2개로 분리하여 인덱스·자식 사이트맵·`<loc>`가 모두 자기 호스트에 속하도록 함.

| 파일 | 변경 |
|------|------|
| `app/functions/sitemap_builder.rb` | `build_locale(locale, host)`로 도메인별 생성. 링크 등재는 `populate`로 분리. `MAX_SITEMAP_LINKS` 상수화 |
| `config/routes.rb` | `/sitemap.xml` 리다이렉트를 호스트 인식형으로 (`.dev`→`/sitemaps/ko/`, `.jp`→`/sitemaps/ja/`) |
| `public/robots.txt` | `Sitemap:` 지시어를 로케일별 경로로 갱신 |
| `config/sitemap.rb` | 출력 경로 주석 갱신 |
| `test/functions/sitemap_builder_test.rb` | `LinkSet`/`populate` 기반으로 테스트 재작성 |

- hreflang alternate(ko↔ja) 상호 참조는 그대로 유지
- 출력: `public/sitemaps/{ko,ja}/`

## 검증

- ✅ 테스트 7개 통과 (21 assertions)
- ✅ **ko** 사이트맵 `<loc>` 4,823개 전부 `ruby-news.dev` / **ja** 4,587개 전부 `ruby-news.jp` (단일 호스트)
- ✅ 강제 분할 시 ja 인덱스가 자식을 `https://ruby-news.jp/sitemaps/ja/sitemapN.xml.gz`로 참조 (크로스도메인 해소 확인)
- ✅ hreflang alternate 유지

## 배포 후 후속 작업 (코드 아님)

1. `rake sitemap:refresh:no_ping` 재생성
2. 프로덕션의 옛 파일(`public/sitemaps/sitemap*.xml.gz`) 삭제
3. GSC 재제출: `.dev`→`/sitemaps/ko/sitemap.xml.gz`, `.jp`→`/sitemaps/ja/sitemap.xml.gz`
4. (선택) Bing Webmaster Tools 제출

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 사이트맵이 언어/도메인별로 분리 생성되며, 각 로케일에 맞는 사이트맵 인덱스와 분할 파일을 제공합니다.
  * 요청한 호스트에 따라 해당 언어의 사이트맵으로 자동 연결됩니다.
* **Bug Fixes**
  * 검색엔진이 더 정확하게 각 언어별 사이트맵을 찾도록 robots.txt와 사이트맵 경로 안내를 정리했습니다.
  * 언어별로 제공 가능한 페이지에만 사이트맵 항목이 포함되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->