### PR TITLE
블로그 글을 @계정/blog URL 네임스페이스로 분리

### DIFF
--- a/app/components/base.rb
+++ b/app/components/base.rb
@@ -16,7 +16,7 @@ class Components::Base < Phlex::HTML
   end
 
   def post_permalink_path(post)
-    if post.blog?
+    if post.blog? && post.user
       user_profile_blog_post_path(username: post.user.username, slug: post)
     else
       post_path(post)

--- a/app/components/base.rb
+++ b/app/components/base.rb
@@ -15,6 +15,14 @@ class Components::Base < Phlex::HTML
     nil
   end
 
+  def post_permalink_path(post)
+    if post.blog?
+      user_profile_blog_post_path(username: post.user.username, slug: post)
+    else
+      post_path(post)
+    end
+  end
+
   if Rails.env.development?
     def before_template
       comment { "Before #{self.class.name}" }

--- a/app/components/posts/post_card.rb
+++ b/app/components/posts/post_card.rb
@@ -64,7 +64,7 @@ class Components::Posts::PostCard < Components::Base
         # navigations to a full show page must break out with turbo_frame: "_top"
         # (otherwise the frame is replaced with "Content missing"). In non-frame
         # contexts like the feed this is just a normal full-page navigation.
-        link_to(post_path(@post), class: "block text-xs text-content-muted hover:text-content transition-colors", data: { turbo_frame: "_top" }) do
+        link_to(post_permalink_path(@post), class: "block text-xs text-content-muted hover:text-content transition-colors", data: { turbo_frame: "_top" }) do
           time(
             datetime: @post.created_at.iso8601,
             title: I18n.l(@post.created_at, format: :long)
@@ -115,12 +115,12 @@ class Components::Posts::PostCard < Components::Base
   def blog_body
     div(class: "space-y-2") do
       h2(class: "text-xl font-semibold text-content") do
-        link_to @post.title, post_path(@post), class: "hover:text-accent-text transition-colors", data: { turbo_frame: "_top" }
+        link_to @post.title, post_permalink_path(@post), class: "hover:text-accent-text transition-colors", data: { turbo_frame: "_top" }
       end
       p(class: "text-sm leading-relaxed text-content-secondary wrap-break-word") do
         plain @post.blog_summary
       end
-      link_to t("posts.blog.read_more"), post_path(@post), class: "text-sm font-medium text-accent-text hover:underline", data: { turbo_frame: "_top" }
+      link_to t("posts.blog.read_more"), post_permalink_path(@post), class: "text-sm font-medium text-accent-text hover:underline", data: { turbo_frame: "_top" }
     end
   end
 

--- a/app/components/profiles/activity_tabs.rb
+++ b/app/components/profiles/activity_tabs.rb
@@ -13,11 +13,11 @@ class Components::Profiles::ActivityTabs < Components::Base
       render RubyUI::TabsList.new do
         tab_link(t("profiles.activity_tabs.posts"), user_profile_posts_path(username: @user.username), :posts)
         tab_link(t("profiles.activity_tabs.comments"), user_profile_comments_path(username: @user.username), :comments)
+        tab_link(t("profiles.activity_tabs.blog"), user_profile_blog_path(username: @user.username), :blog)
         tab_link(t("profiles.activity_tabs.followers"), user_profile_followers_path(username: @user.username), :followers) if own_profile?
         tab_link(t("profiles.activity_tabs.following"), user_profile_following_path(username: @user.username), :following) if own_profile?
         tab_link(t("profiles.activity_tabs.likes"), user_profile_likes_path(username: @user.username), :likes) if own_profile?
         tab_link(t("profiles.activity_tabs.boosts"), user_profile_boosts_path(username: @user.username), :boosts) if own_profile?
-        tab_link(t("profiles.activity_tabs.blog"), user_profile_blog_path(username: @user.username), :blog) if own_profile?
       end
     end
   end

--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -6,6 +6,15 @@ class BlogPostsController < ApplicationController
   before_action :set_post, only: [ :edit, :update, :publish, :destroy, :undiscard, :destroy_permanently ]
   before_action :authorize_owner!, only: [ :edit, :update, :publish, :destroy, :undiscard, :destroy_permanently ]
 
+  def index
+    @drafts    = current_user.posts.blog.draft.kept.order(updated_at: :desc)
+    @published = current_user.posts.blog.published.kept.order(published_at: :desc)
+    @trash     = current_user.posts.blog.discarded.order(updated_at: :desc)
+    render Views::BlogPosts::Index.new(
+      user: current_user, drafts: @drafts, published: @published, trash: @trash
+    )
+  end
+
   # Opens the editor for an unsaved draft. No row is created on entry — the
   # first autosave (or publish) persists it via #create.
   #
@@ -93,7 +102,7 @@ class BlogPostsController < ApplicationController
     # Restoring a published post re-federates via the model's after_undiscard
     # (Undo); drafts were never federated, so nothing is emitted for them.
     @post.undiscard
-    redirect_to user_profile_blog_path(username: current_user.username), notice: t("posts.blog.restored")
+    redirect_to account_blog_path, notice: t("posts.blog.restored")
   end
 
   def destroy_permanently
@@ -103,7 +112,7 @@ class BlogPostsController < ApplicationController
     # is benign — the tombstone already exists remotely, so the second Delete is
     # idempotent.
     @post.destroy
-    redirect_to user_profile_blog_path(username: current_user.username), notice: t("posts.blog.destroyed_permanently")
+    redirect_to account_blog_path, notice: t("posts.blog.destroyed_permanently")
   end
 
   private

--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -37,7 +37,7 @@ class BlogPostsController < ApplicationController
 
     if publishing?
       @post.publish!
-      redirect_to post_path(@post), notice: t("posts.blog.published")
+      redirect_to user_profile_blog_post_path(username: @post.user.username, slug: @post), notice: t("posts.blog.published")
     else
       @post.status = :draft
       @post.title = I18n.t("posts.blog.untitled_draft") if @post.title.blank?
@@ -62,7 +62,7 @@ class BlogPostsController < ApplicationController
   def update
     if @post.update(blog_post_params)
       respond_to do |format|
-        format.html { redirect_to post_path(@post), notice: t("posts.blog.updated") }
+        format.html { redirect_to user_profile_blog_post_path(username: @post.user.username, slug: @post), notice: t("posts.blog.updated") }
         format.json { render json: { status: "ok", saved_at: l(Time.current, format: :short) } }
       end
     else
@@ -76,7 +76,7 @@ class BlogPostsController < ApplicationController
   def publish
     @post.assign_attributes(blog_post_params) if params[:post].present?
     @post.publish!
-    redirect_to post_path(@post), notice: t("posts.blog.published")
+    redirect_to user_profile_blog_post_path(username: @post.user.username, slug: @post), notice: t("posts.blog.published")
   rescue ActiveRecord::RecordInvalid
     render Views::BlogPosts::Edit.new(post: @post), status: :unprocessable_entity
   end

--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -7,11 +7,10 @@ class BlogPostsController < ApplicationController
   before_action :authorize_owner!, only: [ :edit, :update, :publish, :destroy, :undiscard, :destroy_permanently ]
 
   def index
-    @drafts    = current_user.posts.blog.draft.kept.order(updated_at: :desc)
-    @published = current_user.posts.blog.published.kept.order(published_at: :desc)
-    @trash     = current_user.posts.blog.discarded.order(updated_at: :desc)
     render Views::BlogPosts::Index.new(
-      user: current_user, drafts: @drafts, published: @published, trash: @trash
+      drafts: current_user.posts.blog.draft.kept.order(updated_at: :desc),
+      published: current_user.posts.blog.published.kept.order(published_at: :desc),
+      trash: current_user.posts.blog.discarded.order(updated_at: :desc)
     )
   end
 

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+class BlogsController < ApplicationController
+  include PostViewing
+
+  skip_before_action :authenticate_user!, only: [ :show ]
+
+  # GET /@:username/blog/:slug — public blog detail. Scopes by username so the
+  # URL is canonical, but slugs are globally unique so this never ambiguates.
+  def show
+    post = User.find_by!(username: params[:username])
+               .posts.blog.includes(POST_SHOW_INCLUDES)
+               .find_by!(slug: params[:slug])
+    render_post_show(post)
+  end
+end

--- a/app/controllers/concerns/post_viewing.rb
+++ b/app/controllers/concerns/post_viewing.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Shared "render a post thread" behavior for the two controllers that serve a
+# single post's reading page: PostsController (short/comment posts at
+# /posts/:slug) and BlogsController (blog posts at /@user/blog/:slug).
+module PostViewing
+  extend ActiveSupport::Concern
+
+  POST_SHOW_INCLUDES = [ :user, :federails_actor, :article, :tags, { parent: [ :user, :federails_actor ] } ].freeze
+
+  private
+
+  # Renders the reading page for +post+, or 404s if it is not viewable.
+  def render_post_show(post)
+    raise ActiveRecord::RecordNotFound unless viewable?(post)
+    @posts = build_thread(post.root)
+    @liked_post_ids = current_user ? Like.liked_ids_for(liker: current_user, likeable_type: "Post", likeable_ids: @posts.map(&:id)) : []
+    @boosted_post_ids = current_user ? Boost.boosted_ids_for(booster: current_user, boostable_type: "Post", boostable_ids: @posts.map(&:id)) : []
+    render Views::Posts::Show.new(posts: @posts, liked_post_ids: @liked_post_ids, boosted_post_ids: @boosted_post_ids)
+  end
+
+  # A post is publicly viewable when visible (published & kept). The owner may
+  # also preview their own draft. Discarded posts are never served here.
+  def viewable?(post)
+    return true if post.kept? && post.published?
+    return true if post.kept? && current_user && post.user == current_user
+
+    false
+  end
+
+  def build_thread(root)
+    # parent_id 기반으로 안전하게 스레드 수집
+    ids = [ root.id ]
+    queue = [ root.id ]
+    while queue.any?
+      children = Post.kept.where(parent_id: queue).pluck(:id)
+      ids.concat(children)
+      queue = children
+    end
+    Post.kept.where(id: ids).includes(POST_SHOW_INCLUDES).sort_by { |p| [ p.depth, p.created_at ] }
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,6 +3,7 @@
 
 class PostsController < ApplicationController
   include RateLimiting
+  include PostViewing
 
   before_action :authenticate_user!, only: [ :create, :destroy ]
   before_action :set_article, only: [ :create, :destroy ], if: -> { params[:article_id].present? }
@@ -10,13 +11,8 @@ class PostsController < ApplicationController
   before_action :check_rate_limit, only: [ :create ]
 
   def show
-    post = Post.includes(:user, :federails_actor, :article, :tags, parent: [ :user, :federails_actor ]).find_by!(slug: params[:id])
-    raise ActiveRecord::RecordNotFound unless viewable?(post)
-    root = post.root
-    @posts = build_thread(root)
-    @liked_post_ids = current_user ? Like.liked_ids_for(liker: current_user, likeable_type: "Post", likeable_ids: @posts.map(&:id)) : []
-    @boosted_post_ids = current_user ? Boost.boosted_ids_for(booster: current_user, boostable_type: "Post", boostable_ids: @posts.map(&:id)) : []
-    render Views::Posts::Show.new(posts: @posts, liked_post_ids: @liked_post_ids, boosted_post_ids: @boosted_post_ids)
+    post = Post.where.not(post_type: :blog).includes(POST_SHOW_INCLUDES).find_by!(slug: params[:id])
+    render_post_show(post)
   end
 
   def create
@@ -103,16 +99,6 @@ class PostsController < ApplicationController
     @comments = @article.posts.kept.includes(:user)
   end
 
-  # A post is publicly viewable when it is visible (published & kept). The owner
-  # may also preview their own non-published (draft) post. Discarded posts are
-  # never served here — the owner reaches them only via the profile trash tab.
-  def viewable?(post)
-    return true if post.kept? && post.published?
-    return true if post.kept? && current_user && post.user == current_user
-
-    false
-  end
-
   def article_comment_params
     params.expect(post: [ :body, :parent_id ])
   end
@@ -153,17 +139,5 @@ class PostsController < ApplicationController
 
   def default_mention_text_for(actor)
     actor.local? ? actor.short_at_address : actor.at_address
-  end
-
-  def build_thread(root)
-    # parent_id 기반으로 안전하게 스레드 수집
-    ids = [ root.id ]
-    queue = [ root.id ]
-    while queue.any?
-      children = Post.kept.where(parent_id: queue).pluck(:id)
-      ids.concat(children)
-      queue = children
-    end
-    Post.kept.where(id: ids).includes(:user, :federails_actor, :article, :tags, parent: [ :user, :federails_actor ]).sort_by { |p| [ p.depth, p.created_at ] }
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -4,7 +4,7 @@
 class ProfilesController < ApplicationController
   include Pagy::Method
 
-  skip_before_action :authenticate_user!, only: [ :show, :posts, :comments ]
+  skip_before_action :authenticate_user!, only: [ :show, :posts, :comments, :blog ]
 
   before_action :set_user
   before_action :require_own_profile, only: [ :followers, :following ]
@@ -96,14 +96,13 @@ class ProfilesController < ApplicationController
   end
 
   def blog
-    unless current_user == @user
-      redirect_to(user_profile_base_path(username: @user.username),
-                  alert: "본인만 볼 수 있습니다") and return
-    end
-
-    @blog_drafts = @user.posts.blog.draft.kept.order(updated_at: :desc)
-    @blog_published = @user.posts.blog.published.kept.order(published_at: :desc)
-    @blog_trash = @user.posts.blog.discarded.order(updated_at: :desc)
+    @pagy, @posts = pagy(
+      @user.posts.published_blog.kept
+        .includes(:user, :federails_actor, :article, :tags)
+        .order(published_at: :desc)
+    )
+    @liked_post_ids = liked_ids_for_posts(@posts)
+    @boosted_post_ids = boosted_ids_for_posts(@posts)
     render_activity_page(:blog)
   end
 
@@ -154,10 +153,9 @@ class ProfilesController < ApplicationController
       when :blog
         if turbo_frame_request?
           render Views::Profiles::BlogList.new(
-            user: @user,
-            drafts: @blog_drafts,
-            published: @blog_published,
-            trash: @blog_trash
+            user: @user, posts: @posts, pagy: @pagy,
+            liked_post_ids: @liked_post_ids,
+            boosted_post_ids: @boosted_post_ids
           )
         else
           render_show_with_activity(active_tab: :blog)
@@ -187,10 +185,7 @@ class ProfilesController < ApplicationController
         pagy: @pagy,
         liked_post_ids: @liked_post_ids,
         boosted_post_ids: @boosted_post_ids,
-        follow_actors: @follow_actors,
-        blog_drafts: @blog_drafts || [],
-        blog_published: @blog_published || [],
-        blog_trash: @blog_trash || []
+        follow_actors: @follow_actors
       )
     end
 

--- a/app/jobs/reply_notification_job.rb
+++ b/app/jobs/reply_notification_job.rb
@@ -48,6 +48,10 @@ class ReplyNotificationJob < ApplicationJob
         parent_post.article,
         anchor: "post_#{parent_post.id}"
       )
+    elsif parent_post.blog?
+      Rails.application.routes.url_helpers.user_profile_blog_post_path(
+        username: parent_post.user.username, slug: parent_post
+      )
     else
       Rails.application.routes.url_helpers.post_path(parent_post)
     end

--- a/app/models/concerns/posts/federation.rb
+++ b/app/models/concerns/posts/federation.rb
@@ -44,7 +44,7 @@ module Posts::Federation
   # namespace (/@user/blog/:slug); everything else at /posts/:slug.
   #: () -> String
   def public_url
-    if blog?
+    if blog? && user
       Rails.application.routes.url_helpers.user_profile_blog_post_url(username: user.username, slug: self)
     else
       Rails.application.routes.url_helpers.post_url(self)

--- a/app/models/concerns/posts/federation.rb
+++ b/app/models/concerns/posts/federation.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# ActivityPub serialization for Post: builds the outgoing Note object and the
+# canonical public URL advertised to remote servers.
+#
+# Kept out of Post itself so the model stays focused; the enums, scopes, and
+# federation callbacks remain on Post.
+module Posts::Federation
+  extend ActiveSupport::Concern
+
+  #: () -> Hash[String, untyped]
+  def to_activitypub_object
+    custom = {}
+    if parent.present?
+      custom["inReplyTo"] = parent.federated_url || parent.public_url
+    elsif article.present?
+      custom["inReplyTo"] = article.federated_url || Rails.application.routes.url_helpers.article_url(article)
+    end
+
+    if tag_list.any?
+      custom["tag"] = tag_list.map do |name|
+        { "type" => "Hashtag", "name" => "##{name}", "href" => "#{Rails.application.routes.default_url_options[:host]}/tags/#{name}" }
+      end
+    end
+
+    if media_attachments.any?
+      custom["attachment"] = media_attachments
+    end
+
+    content = body
+    name = nil
+
+    if blog?
+      content = blog_summary
+      name = title
+      custom["url"] = public_url
+    end
+
+    Federails::DataTransformer::Note.to_federation(self, content: content, name: name, custom: custom)
+  end
+
+  # Public, human-readable URL for this post. Blog posts live under the account
+  # namespace (/@user/blog/:slug); everything else at /posts/:slug.
+  #: () -> String
+  def public_url
+    if blog?
+      Rails.application.routes.url_helpers.user_profile_blog_post_url(username: user.username, slug: self)
+    else
+      Rails.application.routes.url_helpers.post_url(self)
+    end
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -12,6 +12,7 @@ class Post < ApplicationRecord
   # ── Includes ─────────────────────────────────────────────────────────
   include HtmlSanitizable
   include Posts::Blog
+  include Posts::Federation
   include Discard::Model
   include Federails::DataEntity
   include FederailsLikeable
@@ -94,36 +95,6 @@ class Post < ApplicationRecord
     federation_actor_entity.present? && published?
   end
 
-  #: () -> Hash[String, untyped]
-  def to_activitypub_object
-    custom = {}
-    if parent.present?
-      custom["inReplyTo"] = parent.federated_url || Rails.application.routes.url_helpers.post_url(parent)
-    elsif article.present?
-      custom["inReplyTo"] = article.federated_url || Rails.application.routes.url_helpers.article_url(article)
-    end
-
-    if tag_list.any?
-      custom["tag"] = tag_list.map do |name|
-        { "type" => "Hashtag", "name" => "##{name}", "href" => "#{Rails.application.routes.default_url_options[:host]}/tags/#{name}" }
-      end
-    end
-
-    if media_attachments.any?
-      custom["attachment"] = media_attachments
-    end
-
-    content = body
-    name = nil
-
-    if blog?
-      content = blog_summary
-      name = title
-      custom["url"] = Rails.application.routes.url_helpers.post_url(self)
-    end
-
-    Federails::DataTransformer::Note.to_federation(self, content: content, name: name, custom: custom)
-  end
 
   #: () -> Integer
   def likes_count

--- a/app/views/blog_posts/index.rb
+++ b/app/views/blog_posts/index.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+class Views::BlogPosts::Index < Views::Base
+  include Phlex::Rails::Helpers::ContentFor
+  include Phlex::Rails::Helpers::LinkTo
+  include Phlex::Rails::Helpers::ButtonTo
+
+  def initialize(user:, drafts: [], published: [], trash: [])
+    @user = user
+    @drafts = drafts
+    @published = published
+    @trash = trash
+  end
+
+  def view_template
+    content_for :title, t("posts.blog.manage_title")
+    div(class: "max-w-2xl mx-auto py-10 px-4 sm:px-6") do
+      div(class: "mb-6 px-1") do
+        render RubyUI::Heading.new(level: 1, class: "text-2xl font-bold text-content tracking-tight") { t("posts.blog.manage_heading") }
+      end
+      div(class: "flex flex-col gap-8") do
+        drafts_section
+        published_section
+        trash_section
+      end
+    end
+  end
+
+  private
+
+  def drafts_section
+    section(class: "flex flex-col gap-3") do
+      h2(class: "text-sm font-semibold text-content") { t("profiles.blog_list.drafts_heading") }
+      drafts = @drafts.to_a
+      if drafts.empty?
+        empty_state(t("profiles.blog_list.drafts_empty"))
+      else
+        div(class: "flex flex-col gap-2") { drafts.each { |d| draft_row(d) } }
+      end
+    end
+  end
+
+  def published_section
+    section(class: "flex flex-col gap-3") do
+      h2(class: "text-sm font-semibold text-content") { t("profiles.blog_list.published_heading") }
+      published = @published.to_a
+      if published.empty?
+        empty_state(t("profiles.blog_list.published_empty"))
+      else
+        div(class: "flex flex-col gap-2") { published.each { |p| published_row(p) } }
+      end
+    end
+  end
+
+  def trash_section
+    section(class: "flex flex-col gap-3") do
+      h2(class: "text-sm font-semibold text-content") { t("profiles.blog_list.trash_heading") }
+      trash = @trash.to_a
+      if trash.empty?
+        empty_state(t("profiles.blog_list.trash_empty"))
+      else
+        div(class: "flex flex-col gap-2") { trash.each { |p| trash_row(p) } }
+      end
+    end
+  end
+
+  def empty_state(message)
+    div(class: "text-center py-8 text-content-disabled") { p { message } }
+  end
+
+  def draft_row(draft)
+    row do
+      link_to(edit_blog_post_path(draft),
+        class: "min-w-0 flex-1 truncate text-sm text-content hover:text-brand-text transition-colors",
+        data: { turbo_prefetch: false }) do
+        plain draft.title.presence || t("posts.blog.untitled_draft")
+      end
+      div(class: "flex items-center gap-2 shrink-0") do
+        button_to t("posts.blog.delete"), blog_post_path(draft),
+          method: :delete,
+          form: { data: { turbo_confirm: t("posts.blog.delete_confirm") } },
+          class: "text-xs font-medium text-content-muted hover:text-danger-text transition-colors cursor-pointer"
+      end
+    end
+  end
+
+  def published_row(post)
+    row do
+      link_to(post_permalink_path(post),
+        class: "min-w-0 flex-1 truncate text-sm text-content hover:text-brand-text transition-colors") do
+        plain post.title.presence || t("posts.blog.untitled_draft")
+      end
+      div(class: "flex items-center gap-2 shrink-0") do
+        link_to t("posts.blog.edit"), edit_blog_post_path(post),
+          class: "text-xs font-medium text-content-muted hover:text-content transition-colors",
+          data: { turbo_prefetch: false }
+        button_to t("posts.blog.delete"), blog_post_path(post),
+          method: :delete,
+          form: { data: { turbo_confirm: t("posts.blog.delete_confirm") } },
+          class: "text-xs font-medium text-content-muted hover:text-danger-text transition-colors cursor-pointer"
+      end
+    end
+  end
+
+  def trash_row(post)
+    row do
+      span(class: "min-w-0 flex-1 truncate text-sm text-content") do
+        plain post.title.presence || t("posts.blog.untitled_draft")
+      end
+      div(class: "flex items-center gap-2 shrink-0") do
+        button_to t("posts.blog.restore"), undiscard_blog_post_path(post),
+          method: :patch,
+          class: "text-xs font-medium text-content-muted hover:text-content transition-colors cursor-pointer"
+        button_to t("posts.blog.destroy_permanently"), destroy_permanently_blog_post_path(post),
+          method: :delete,
+          form: { data: { turbo_confirm: t("posts.blog.destroy_permanently_confirm") } },
+          class: "text-xs font-medium text-content-muted hover:text-danger-text transition-colors cursor-pointer"
+      end
+    end
+  end
+
+  def row(&block)
+    div(class: "flex items-center justify-between gap-3 rounded-md border border-border-muted bg-app/40 px-3 py-2", &block)
+  end
+end

--- a/app/views/blog_posts/index.rb
+++ b/app/views/blog_posts/index.rb
@@ -5,8 +5,7 @@ class Views::BlogPosts::Index < Views::Base
   include Phlex::Rails::Helpers::LinkTo
   include Phlex::Rails::Helpers::ButtonTo
 
-  def initialize(user:, drafts: [], published: [], trash: [])
-    @user = user
+  def initialize(drafts: [], published: [], trash: [])
     @drafts = drafts
     @published = published
     @trash = trash

--- a/app/views/profiles/blog_list.rb
+++ b/app/views/profiles/blog_list.rb
@@ -3,14 +3,13 @@
 class Views::Profiles::BlogList < Views::Base
   include Phlex::Rails::Helpers::ContentFor
   include Phlex::Rails::Helpers::TurboFrameTag
-  include Phlex::Rails::Helpers::LinkTo
-  include Phlex::Rails::Helpers::ButtonTo
 
-  def initialize(user:, drafts: [], published: [], trash: [], embedded: false)
+  def initialize(user:, posts:, pagy:, liked_post_ids: [], boosted_post_ids: [], embedded: false)
     @user = user
-    @drafts = drafts
-    @published = published
-    @trash = trash
+    @posts = posts
+    @pagy = pagy
+    @liked_post_ids = liked_post_ids
+    @boosted_post_ids = boosted_post_ids
     @embedded = embedded
   end
 
@@ -31,122 +30,23 @@ class Views::Profiles::BlogList < Views::Base
   private
 
   def list_content
-    div(class: "flex flex-col gap-8") do
-      drafts_section
-      published_section
-      trash_section
-    end
-  end
-
-  def drafts_section
-    section(class: "flex flex-col gap-3") do
-      h2(class: "text-sm font-semibold text-content") { t("profiles.blog_list.drafts_heading") }
-      drafts = @drafts.to_a
-      if drafts.empty?
-        empty_state(t("profiles.blog_list.drafts_empty"))
-      else
-        div(class: "flex flex-col gap-2") do
-          drafts.each { |draft| draft_row(draft) }
+    if @posts.empty?
+      div(class: "text-center py-16 text-content-disabled") do
+        p { t("profiles.blog_list.empty") }
+      end
+    else
+      div(class: "flex flex-col gap-4") do
+        div(class: "flex flex-col gap-3") do
+          @posts.each do |post|
+            render Components::Posts::PostCard.new(
+              post: post,
+              liked: @liked_post_ids.include?(post.id),
+              boosted: @boosted_post_ids.include?(post.id)
+            )
+          end
         end
+        render Components::Pagination.new(pagy: @pagy)
       end
     end
-  end
-
-  def published_section
-    section(class: "flex flex-col gap-3") do
-      h2(class: "text-sm font-semibold text-content") { t("profiles.blog_list.published_heading") }
-      published = @published.to_a
-      if published.empty?
-        empty_state(t("profiles.blog_list.published_empty"))
-      else
-        div(class: "flex flex-col gap-2") do
-          published.each { |post| published_row(post) }
-        end
-      end
-    end
-  end
-
-  def trash_section
-    section(class: "flex flex-col gap-3") do
-      h2(class: "text-sm font-semibold text-content") { t("profiles.blog_list.trash_heading") }
-      trash = @trash.to_a
-      if trash.empty?
-        empty_state(t("profiles.blog_list.trash_empty"))
-      else
-        div(class: "flex flex-col gap-2") do
-          trash.each { |post| trash_row(post) }
-        end
-      end
-    end
-  end
-
-  def empty_state(message)
-    div(class: "text-center py-8 text-content-disabled") do
-      p { message }
-    end
-  end
-
-  # All controls render inside the "activity-list" turbo frame, so links/forms
-  # use data-turbo-frame="_top" to navigate the whole page rather than
-  # replacing the frame (which would otherwise show "Content missing").
-  def draft_row(draft)
-    row do
-      link_to(
-        edit_blog_post_path(draft),
-        class: "min-w-0 flex-1 truncate text-sm text-content hover:text-brand-text transition-colors",
-        data: { turbo_frame: "_top", turbo_prefetch: false }
-      ) do
-        plain draft.title.presence || t("posts.blog.untitled_draft")
-      end
-      div(class: "flex items-center gap-2 shrink-0") do
-        button_to t("posts.blog.delete"), blog_post_path(draft),
-          method: :delete,
-          form: { data: { turbo_confirm: t("posts.blog.delete_confirm"), turbo_frame: "_top" } },
-          class: "text-xs font-medium text-content-muted hover:text-danger-text transition-colors cursor-pointer"
-      end
-    end
-  end
-
-  def published_row(post)
-    row do
-      link_to(
-        post_path(post),
-        class: "min-w-0 flex-1 truncate text-sm text-content hover:text-brand-text transition-colors",
-        data: { turbo_frame: "_top" }
-      ) do
-        plain post.title.presence || t("posts.blog.untitled_draft")
-      end
-      div(class: "flex items-center gap-2 shrink-0") do
-        link_to t("posts.blog.edit"), edit_blog_post_path(post),
-          class: "text-xs font-medium text-content-muted hover:text-content transition-colors",
-          data: { turbo_frame: "_top", turbo_prefetch: false }
-        button_to t("posts.blog.delete"), blog_post_path(post),
-          method: :delete,
-          form: { data: { turbo_confirm: t("posts.blog.delete_confirm"), turbo_frame: "_top" } },
-          class: "text-xs font-medium text-content-muted hover:text-danger-text transition-colors cursor-pointer"
-      end
-    end
-  end
-
-  def trash_row(post)
-    row do
-      span(class: "min-w-0 flex-1 truncate text-sm text-content") do
-        plain post.title.presence || t("posts.blog.untitled_draft")
-      end
-      div(class: "flex items-center gap-2 shrink-0") do
-        button_to t("posts.blog.restore"), undiscard_blog_post_path(post),
-          method: :patch,
-          form: { data: { turbo_frame: "_top" } },
-          class: "text-xs font-medium text-content-muted hover:text-content transition-colors cursor-pointer"
-        button_to t("posts.blog.destroy_permanently"), destroy_permanently_blog_post_path(post),
-          method: :delete,
-          form: { data: { turbo_confirm: t("posts.blog.destroy_permanently_confirm"), turbo_frame: "_top" } },
-          class: "text-xs font-medium text-content-muted hover:text-danger-text transition-colors cursor-pointer"
-      end
-    end
-  end
-
-  def row(&block)
-    div(class: "flex items-center justify-between gap-3 rounded-md border border-border-muted bg-app/40 px-3 py-2", &block)
   end
 end

--- a/app/views/profiles/show.rb
+++ b/app/views/profiles/show.rb
@@ -10,8 +10,7 @@ class Views::Profiles::Show < Views::Base
   def initialize(user:, actor:, followers_count: 0, following_count: 0,
                  follow_actors: nil,
                  active_tab: :posts, posts: nil, likeables: nil, boostables: nil, pagy: nil,
-                 liked_post_ids: [], boosted_post_ids: [],
-                 blog_drafts: [], blog_published: [], blog_trash: [])
+                 liked_post_ids: [], boosted_post_ids: [])
     @user = user
     @actor = actor
     @followers_count = followers_count
@@ -24,9 +23,6 @@ class Views::Profiles::Show < Views::Base
     @pagy = pagy
     @liked_post_ids = liked_post_ids
     @boosted_post_ids = boosted_post_ids
-    @blog_drafts = blog_drafts
-    @blog_published = blog_published
-    @blog_trash = blog_trash
   end
 
   def view_template
@@ -133,8 +129,9 @@ class Views::Profiles::Show < Views::Base
       )
     when :blog
       render Views::Profiles::BlogList.new(
-        user: @user, drafts: @blog_drafts, published: @blog_published,
-        trash: @blog_trash, embedded: true
+        user: @user, posts: @posts || [], pagy: @pagy,
+        liked_post_ids: @liked_post_ids,
+        boosted_post_ids: @boosted_post_ids, embedded: true
       )
     when :followers, :following
       render Views::Profiles::FollowList.new(

--- a/app/views/users/edit.rb
+++ b/app/views/users/edit.rb
@@ -2,6 +2,7 @@
 
 class Views::Users::Edit < Views::Base
   include Phlex::Rails::Helpers::ContentFor
+  include Phlex::Rails::Helpers::LinkTo
   include PhlexIcons
 
   def initialize(user:)
@@ -18,6 +19,11 @@ class Views::Users::Edit < Views::Base
       end
 
       render Components::Users::Form.new(user: @user)
+
+      div(class: "mt-6 px-1") do
+        link_to t("users.edit.blog_link"), account_blog_path,
+          class: "text-sm font-medium text-accent-text hover:underline"
+      end
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -280,7 +280,7 @@ en:
       status_draft: Draft
       status_published: Published
       read_more: Read full post
-      manage_title: Manage blog posts
+      manage_title: Manage blog posts | Ruby-News
       manage_heading: Manage blog posts
       errors:
         blank_draft: Enter a title or body before saving this draft.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -335,6 +335,7 @@ en:
       drafts_empty: No drafts in progress.
       published_empty: No published blog posts.
       trash_empty: Trash is empty.
+      empty: No published blog posts yet.
     show:
       feed: Feed
       find_follow: Find & Follow

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -280,6 +280,8 @@ en:
       status_draft: Draft
       status_published: Published
       read_more: Read full post
+      manage_title: Manage blog posts
+      manage_heading: Manage blog posts
       errors:
         blank_draft: Enter a title or body before saving this draft.
     post_card:
@@ -378,6 +380,7 @@ en:
       heading: Edit Profile
       subtitle: Update your account information.
       title: Edit Profile
+      blog_link: Manage blog posts
     form:
       avatar_alt_default: Profile picture
       avatar_hint: Will be cropped to 400×400 as a square thumbnail and displayed publicly.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -280,6 +280,8 @@ ja:
       status_draft: 下書き
       status_published: 公開済み
       read_more: 本文を読む
+      manage_title: ブログ記事の管理
+      manage_heading: ブログ記事の管理
       errors:
         blank_draft: 下書きを保存するにはタイトルまたは本文を入力してください。
     post_card:
@@ -378,6 +380,7 @@ ja:
       heading: ユーザー情報を編集
       subtitle: アカウント情報を更新します。
       title: ユーザー情報を編集
+      blog_link: ブログ記事の管理
     form:
       avatar_alt_default: プロフィール画像
       avatar_hint: 正方形の代表サムネイルとして400x400にクロップされ、外部に公開されます。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -280,7 +280,7 @@ ja:
       status_draft: 下書き
       status_published: 公開済み
       read_more: 本文を読む
-      manage_title: ブログ記事の管理
+      manage_title: ブログ記事の管理 | Ruby-News
       manage_heading: ブログ記事の管理
       errors:
         blank_draft: 下書きを保存するにはタイトルまたは本文を入力してください。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -335,6 +335,7 @@ ja:
       drafts_empty: 作成中の下書きはありません。
       published_empty: 公開したブログはありません。
       trash_empty: ゴミ箱は空です。
+      empty: まだ公開されたブログ記事がありません。
     show:
       feed: フィード
       find_follow: フォロー検索

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -335,6 +335,7 @@ ko:
       drafts_empty: 작성 중인 초안이 없습니다.
       published_empty: 발행한 블로그가 없습니다.
       trash_empty: 휴지통이 비어 있습니다.
+      empty: 아직 발행한 블로그 글이 없습니다.
     show:
       feed: Feed
       find_follow: 팔로우 검색

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -280,7 +280,7 @@ ko:
       status_draft: 초안
       status_published: 발행됨
       read_more: 원문 읽기
-      manage_title: 블로그 글 관리
+      manage_title: 블로그 글 관리 | Ruby-News
       manage_heading: 블로그 글 관리
       errors:
         blank_draft: 제목이나 본문 중 하나는 입력해야 합니다.

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -280,6 +280,8 @@ ko:
       status_draft: 초안
       status_published: 발행됨
       read_more: 원문 읽기
+      manage_title: 블로그 글 관리
+      manage_heading: 블로그 글 관리
       errors:
         blank_draft: 제목이나 본문 중 하나는 입력해야 합니다.
     post_card:
@@ -378,6 +380,7 @@ ko:
       heading: 사용자 정보 수정
       subtitle: 계정 정보를 업데이트합니다.
       title: 사용자 정보 수정
+      blog_link: 블로그 글 관리
     form:
       avatar_alt_default: 프로필 이미지
       avatar_hint: 정사각형 대표 썸네일로 400x400 크롭되어 외부에 공개됩니다.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
     post "account/oauth-signup", to: "users/oauth_registrations#create", as: :user_oauth_registration
   end
 
+  get "account/blog", to: "blog_posts#index", as: :account_blog
+
   namespace :api do
     namespace :v1 do
       namespace :auth do
@@ -113,6 +115,7 @@ Rails.application.routes.draw do
   get "/@:username/likes",    to: "profiles#likes",    as: :user_profile_likes, format: false, constraints: { username: /[^\/]+/ }
   get "/@:username/boosts",   to: "profiles#boosts",   as: :user_profile_boosts, format: false, constraints: { username: /[^\/]+/ }
   get "/@:username/blog", to: "profiles#blog", as: :user_profile_blog, format: false, constraints: { username: /[^\/]+/ }
+  get "/@:username/blog/:slug", to: "blogs#show", as: :user_profile_blog_post, format: false, constraints: { username: /[^\/]+/ }
   # 2. 헬퍼 메서드 오버라이드 (URL 생성 로직)
   direct :user_profile do |user|
     # user 객체에서 username을 뽑아 위에서 정의한 경로로 보냅니다.

--- a/docs/superpowers/plans/2026-07-06-blog-public-index.md
+++ b/docs/superpowers/plans/2026-07-06-blog-public-index.md
@@ -135,6 +135,201 @@ git commit -m "feat: serve blog detail at /@user/blog/:slug, add account/blog ro
 
 ---
 
+### Task 1b: Extract blog detail into `BlogsController#show` (revises Task 1's show branch)
+
+> **Consolidated commit:** Task 1 was soft-reset (its changes remain staged in the working tree: routes, `post_permalink_path`, fixture slug, legacy-404 tests, and the now-obsolete `posts#show` branch). This task is applied ON TOP of that staged tree and the whole thing lands as ONE clean commit — no add-then-remove churn in history. The obsolete `posts#show` blog branch / `find_show_post` are rolled back here as part of Step 4.
+
+**Decision (post-Task-1):** blog *detail* gets its own controller for isolation and as the future home of a magazine renewal. The blog *index* stays a profile tab (`profiles#blog`, Task 3) — moving it would duplicate profile-page assembly. `PostsController#show` reverts to non-blog only. Shared show logic (`viewable?`, `build_thread`) moves to a controller concern.
+
+**Files:**
+- Create: `app/controllers/concerns/post_viewing.rb`
+- Create: `app/controllers/blogs_controller.rb`
+- Modify: `config/routes.rb` (blog-detail route target → `blogs#show`)
+- Modify: `app/controllers/posts_controller.rb` (include concern; simplify `#show`; delete `find_show_post`, `viewable?`, `build_thread`)
+- Create: `test/controllers/blogs_controller_test.rb` (blog-show tests moved from posts test + wrong-username 404)
+- Modify: `test/controllers/posts_controller_test.rb` (remove the moved blog-show tests; keep legacy-404 + short-post tests)
+
+**Interfaces:**
+- Consumes: route helper `user_profile_blog_post_path` (unchanged name — Task 2 links stay valid); `Views::Posts::Show`.
+- Produces: concern `PostViewing` (private `render_post_show(post)`, `viewable?(post)`, `build_thread(root)`, `POST_SHOW_INCLUDES`); `BlogsController#show`.
+
+- [ ] **Step 1: Create the `PostViewing` concern**
+
+Create `app/controllers/concerns/post_viewing.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+# Shared "render a post thread" behavior for the two controllers that serve a
+# single post's reading page: PostsController (short/comment posts at
+# /posts/:slug) and BlogsController (blog posts at /@user/blog/:slug).
+module PostViewing
+  extend ActiveSupport::Concern
+
+  POST_SHOW_INCLUDES = [ :user, :federails_actor, :article, :tags, { parent: [ :user, :federails_actor ] } ].freeze
+
+  private
+
+  # Renders the reading page for +post+, or 404s if it is not viewable.
+  def render_post_show(post)
+    raise ActiveRecord::RecordNotFound unless viewable?(post)
+    @posts = build_thread(post.root)
+    @liked_post_ids = current_user ? Like.liked_ids_for(liker: current_user, likeable_type: "Post", likeable_ids: @posts.map(&:id)) : []
+    @boosted_post_ids = current_user ? Boost.boosted_ids_for(booster: current_user, boostable_type: "Post", boostable_ids: @posts.map(&:id)) : []
+    render Views::Posts::Show.new(posts: @posts, liked_post_ids: @liked_post_ids, boosted_post_ids: @boosted_post_ids)
+  end
+
+  # A post is publicly viewable when visible (published & kept). The owner may
+  # also preview their own draft. Discarded posts are never served here.
+  def viewable?(post)
+    return true if post.kept? && post.published?
+    return true if post.kept? && current_user && post.user == current_user
+
+    false
+  end
+
+  def build_thread(root)
+    # parent_id 기반으로 안전하게 스레드 수집
+    ids = [ root.id ]
+    queue = [ root.id ]
+    while queue.any?
+      children = Post.kept.where(parent_id: queue).pluck(:id)
+      ids.concat(children)
+      queue = children
+    end
+    Post.kept.where(id: ids).includes(POST_SHOW_INCLUDES).sort_by { |p| [ p.depth, p.created_at ] }
+  end
+end
+```
+
+- [ ] **Step 2: Create `BlogsController`**
+
+Create `app/controllers/blogs_controller.rb`:
+
+```ruby
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+class BlogsController < ApplicationController
+  include PostViewing
+
+  skip_before_action :authenticate_user!, only: [ :show ]
+
+  # GET /@:username/blog/:slug — public blog detail. Scopes by username so the
+  # URL is canonical, but slugs are globally unique so this never ambiguates.
+  def show
+    post = User.find_by!(username: params[:username])
+               .posts.blog.includes(POST_SHOW_INCLUDES)
+               .find_by!(slug: params[:slug])
+    render_post_show(post)
+  end
+end
+```
+
+- [ ] **Step 3: Point the blog-detail route at `blogs#show`**
+
+In `config/routes.rb`, change the blog-detail route target from `posts#show` to `blogs#show` (keep the helper name `user_profile_blog_post`):
+
+```ruby
+  get "/@:username/blog/:slug", to: "blogs#show", as: :user_profile_blog_post, format: false, constraints: { username: /[^\/]+/ }
+```
+
+- [ ] **Step 4: Simplify `PostsController#show` and remove the moved methods**
+
+In `app/controllers/posts_controller.rb`:
+
+- Add `include PostViewing` near the top (after `include RateLimiting` on line 5).
+- Replace `#show` (currently delegating to `find_show_post`) with:
+
+```ruby
+  def show
+    post = Post.where.not(post_type: :blog).includes(POST_SHOW_INCLUDES).find_by!(slug: params[:id])
+    render_post_show(post)
+  end
+```
+
+- Delete the now-unused private methods from this controller: `find_show_post` (lines ~106-113), `viewable?` (lines ~115-123), and `build_thread` (lines ~167-177) — they now live in `PostViewing`.
+
+- [ ] **Step 5: Move blog-show tests to a new `BlogsControllerTest`**
+
+Create `test/controllers/blogs_controller_test.rb` with the six blog-detail tests (moved out of `posts_controller_test.rb`) plus a wrong-username 404 test:
+
+```ruby
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BlogsControllerTest < ActionDispatch::IntegrationTest
+  test "shows a published blog post with the reading layout to anyone" do
+    post = posts(:blog_published)
+
+    get user_profile_blog_post_url(username: post.user.username, slug: post)
+
+    assert_response :success
+    assert_includes response.body, post.title
+  end
+
+  test "draft blog post is not served to anonymous visitors" do
+    draft = posts(:blog_draft)
+
+    get user_profile_blog_post_url(username: draft.user.username, slug: draft)
+
+    assert_response :not_found
+  end
+
+  test "draft blog post is not served to a non-owner" do
+    draft = posts(:blog_draft)
+    sign_in users(:jane)
+
+    get user_profile_blog_post_url(username: draft.user.username, slug: draft)
+
+    assert_response :not_found
+  end
+
+  test "owner can preview their own draft blog post" do
+    draft = posts(:blog_draft)
+    sign_in draft.user
+
+    get user_profile_blog_post_url(username: draft.user.username, slug: draft)
+
+    assert_response :success
+  end
+
+  test "discarded blog post is not served publicly" do
+    post = posts(:blog_published)
+    post.discard!
+
+    get user_profile_blog_post_url(username: post.user.username, slug: post)
+
+    assert_response :not_found
+  end
+
+  test "correct slug under the wrong username is not found" do
+    post = posts(:blog_published)
+
+    get user_profile_blog_post_url(username: users(:jane).username, slug: post)
+
+    assert_response :not_found
+  end
+end
+```
+
+Then in `test/controllers/posts_controller_test.rb`, DELETE the six blog-detail tests that Task 1 pointed at `user_profile_blog_post_url` ("should show blog post with reading layout", "published post is served to anyone", "draft is not served to anonymous visitors", "draft is not served to a non-owner", "owner can preview their own draft", "discarded blog is not served publicly"). KEEP the two legacy tests added in Task 1: "blog post is not served at legacy /posts/:slug" and "short post is still served at /posts/:slug".
+
+- [ ] **Step 6: Run the affected tests**
+
+Run: `mise x -- bin/rails test test/controllers/blogs_controller_test.rb test/controllers/posts_controller_test.rb`
+Expected: PASS (blog detail served by BlogsController; legacy /posts/:slug 404s blog, serves short).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/controllers/concerns/post_viewing.rb app/controllers/blogs_controller.rb config/routes.rb app/controllers/posts_controller.rb test/controllers/blogs_controller_test.rb test/controllers/posts_controller_test.rb
+git commit -m "refactor: serve blog detail from BlogsController#show via PostViewing concern"
+```
+
+---
+
 ### Task 2: Route blog links through `post_permalink_path` (PostCard, controller redirects, reply job)
 
 Every blog link/redirect must target the new URL. Legacy `post_path` for blog posts now 404s, so this task prevents broken links introduced by Task 1.

--- a/docs/superpowers/plans/2026-07-06-blog-public-index.md
+++ b/docs/superpowers/plans/2026-07-06-blog-public-index.md
@@ -4,7 +4,7 @@
 
 **Goal:** `/@user/blog` becomes the public blog index and `/@user/blog/:slug` the public blog detail; blog authoring/management moves to `/account/blog`.
 
-**Architecture:** Reuse the existing profile activity-tab infrastructure (`ActivityTabs`, `render_activity_page`) — the `blog` tab flips from owner-only to public and renders published posts with `PostCard`, mirroring the `posts` tab. Blog detail is served by the existing `PostsController#show`, now branching on a nested `/@:username/blog/:slug` route (slugs are globally unique via `friendly_id`). A single `post_permalink_path` helper routes blog links to the new URL. Legacy `/posts/:slug` no longer serves blog posts (destructive — only 1 blog post exists today).
+**Architecture:** Reuse the existing profile activity-tab infrastructure (`ActivityTabs`, `render_activity_page`) — the `blog` tab flips from owner-only to public and renders published posts with `PostCard`, mirroring the `posts` tab. Blog detail is served by a dedicated `BlogsController#show` on the nested `/@:username/blog/:slug` route (slugs are globally unique via `friendly_id`), with the shared thread-rendering logic extracted into a `PostViewing` concern; `PostsController#show` is simplified to non-blog posts only. A single `post_permalink_path` helper routes blog links to the new URL. Legacy `/posts/:slug` no longer serves blog posts (destructive — only 1 blog post exists today). (See Task 1b for the final controller split.)
 
 **Tech Stack:** Rails 8.1 / Ruby 4.0, Phlex views/components, Devise auth, Minitest + fixtures (`test/`), Discard soft-delete, FriendlyId slugs, Federails.
 

--- a/docs/superpowers/plans/2026-07-06-blog-public-index.md
+++ b/docs/superpowers/plans/2026-07-06-blog-public-index.md
@@ -1,0 +1,797 @@
+# Blog Public Index & Detail Namespacing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `/@user/blog` becomes the public blog index and `/@user/blog/:slug` the public blog detail; blog authoring/management moves to `/account/blog`.
+
+**Architecture:** Reuse the existing profile activity-tab infrastructure (`ActivityTabs`, `render_activity_page`) — the `blog` tab flips from owner-only to public and renders published posts with `PostCard`, mirroring the `posts` tab. Blog detail is served by the existing `PostsController#show`, now branching on a nested `/@:username/blog/:slug` route (slugs are globally unique via `friendly_id`). A single `post_permalink_path` helper routes blog links to the new URL. Legacy `/posts/:slug` no longer serves blog posts (destructive — only 1 blog post exists today).
+
+**Tech Stack:** Rails 8.1 / Ruby 4.0, Phlex views/components, Devise auth, Minitest + fixtures (`test/`), Discard soft-delete, FriendlyId slugs, Federails.
+
+## Global Constraints
+
+- Tests: **Minitest** (`ActionDispatch::IntegrationTest` / `ApplicationSystemTestCase`) under `test/`, using fixtures (`users(:john)`, `users(:jane)`, `posts(:blog_published)`, `posts(:blog_draft)`). NOT RSpec.
+- Run Ruby commands via mise: `mise x -- <cmd>` (e.g. `mise x -- bin/rails test test/...`).
+- Slugs are globally unique (`friendly_id :random_slug`); username in the blog-detail route is vanity/scoping, not the lookup key.
+- Phlex route helpers are available in `Components::Base`/`Views::Base` via `Phlex::Rails::Helpers::Routes` — call `user_profile_blog_post_path(...)` / `post_path(...)` directly.
+- Every new i18n key MUST be added to all three locales: `config/locales/en.yml`, `ja.yml`, `ko.yml`.
+- Blog viewability rule (unchanged): a post is viewable if `kept? && published?`, OR `kept? && current_user == owner` (draft preview). Preserved by reusing `PostsController#viewable?`.
+- After each task run the RuboCop/RBS pre-commit hook (runs automatically on commit); keep edits `# frozen_string_literal: true` compliant.
+
+---
+
+### Task 1: Routes, `PostsController#show` branching, and `post_permalink_path` helper
+
+Blog detail moves to `/@:username/blog/:slug`; legacy `/posts/:slug` stops serving blog posts. Add the shared permalink helper both later tasks depend on.
+
+**Files:**
+- Modify: `config/routes.rb` (after line 115, the blog index route)
+- Modify: `app/controllers/posts_controller.rb:12-20` (`#show`) + add private `find_show_post`
+- Modify: `app/components/base.rb` (add `post_permalink_path`)
+- Test: `test/controllers/posts_controller_test.rb` (update blog-show tests + add legacy-404 tests)
+
+**Interfaces:**
+- Produces: route helper `user_profile_blog_post_path(username:, slug:)` → `/@:username/blog/:slug`; route helper `account_blog_path` → `/account/blog`; instance method `post_permalink_path(post)` on `Components::Base` (and subclasses incl. `Views::Base`) returning the blog URL for `post.blog?` else `post_path(post)`.
+
+- [ ] **Step 1: Add the two routes**
+
+In `config/routes.rb`, immediately after the existing blog index line (`get "/@:username/blog", ...` at line 115) add:
+
+```ruby
+  get "/@:username/blog/:slug", to: "posts#show", as: :user_profile_blog_post, format: false, constraints: { username: /[^\/]+/ }
+```
+
+And after the `devise_scope :user do ... end` block (after line 24) add the management route:
+
+```ruby
+  get "account/blog", to: "blog_posts#index", as: :account_blog
+```
+
+- [ ] **Step 2: Branch `PostsController#show` on the route**
+
+Replace `app/controllers/posts_controller.rb` lines 12-20 with:
+
+```ruby
+  def show
+    post = find_show_post
+    raise ActiveRecord::RecordNotFound unless viewable?(post)
+    root = post.root
+    @posts = build_thread(root)
+    @liked_post_ids = current_user ? Like.liked_ids_for(liker: current_user, likeable_type: "Post", likeable_ids: @posts.map(&:id)) : []
+    @boosted_post_ids = current_user ? Boost.boosted_ids_for(booster: current_user, boostable_type: "Post", boostable_ids: @posts.map(&:id)) : []
+    render Views::Posts::Show.new(posts: @posts, liked_post_ids: @liked_post_ids, boosted_post_ids: @boosted_post_ids)
+  end
+```
+
+Then add this private method (near the other private helpers, e.g. just above `def viewable?` at line 109):
+
+```ruby
+  def find_show_post
+    includes = [ :user, :federails_actor, :article, :tags, { parent: [ :user, :federails_actor ] } ]
+    if params[:username]
+      User.find_by!(username: params[:username]).posts.blog.includes(includes).find_by!(slug: params[:slug])
+    else
+      Post.where.not(post_type: :blog).includes(includes).find_by!(slug: params[:id])
+    end
+  end
+```
+
+- [ ] **Step 3: Add `post_permalink_path` to `Components::Base`**
+
+In `app/components/base.rb`, inside the `private` section (after `safe_url`), add:
+
+```ruby
+  def post_permalink_path(post)
+    if post.blog?
+      user_profile_blog_post_path(username: post.user.username, slug: post)
+    else
+      post_path(post)
+    end
+  end
+```
+
+- [ ] **Step 4: Update blog-show tests to the new URL + add legacy-404 tests**
+
+In `test/controllers/posts_controller_test.rb`, replace every blog-post `get post_url(...)` in the show tests (the block around lines 104-152) with the nested helper. Concretely:
+
+- "should show blog post with reading layout": `get user_profile_blog_post_url(username: post.user.username, slug: post)`
+- "published post is served to anyone": `get user_profile_blog_post_url(username: post.user.username, slug: post)`
+- "draft is not served to anonymous visitors": `get user_profile_blog_post_url(username: draft.user.username, slug: draft)` (still `assert_response :not_found`)
+- "draft is not served to a non-owner": `get user_profile_blog_post_url(username: draft.user.username, slug: draft)` (still `:not_found`)
+- "owner can preview their own draft": `get user_profile_blog_post_url(username: draft.user.username, slug: draft)` (still `:success`)
+- "discarded blog is not served publicly": `get user_profile_blog_post_url(username: post.user.username, slug: post)` (still `:not_found`)
+
+Then append two new tests to the class:
+
+```ruby
+  test "blog post is not served at legacy /posts/:slug" do
+    blog = posts(:blog_published)
+
+    get post_url(blog)
+
+    assert_response :not_found
+  end
+
+  test "short post is still served at /posts/:slug" do
+    short = posts(:short_with_article)
+
+    get post_url(short)
+
+    assert_response :success
+  end
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `mise x -- bin/rails test test/controllers/posts_controller_test.rb`
+Expected: PASS (all show tests green, legacy blog URL returns 404, short post still served).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add config/routes.rb app/controllers/posts_controller.rb app/components/base.rb test/controllers/posts_controller_test.rb
+git commit -m "feat: serve blog detail at /@user/blog/:slug, add account/blog route + permalink helper"
+```
+
+---
+
+### Task 2: Route blog links through `post_permalink_path` (PostCard, controller redirects, reply job)
+
+Every blog link/redirect must target the new URL. Legacy `post_path` for blog posts now 404s, so this task prevents broken links introduced by Task 1.
+
+**Files:**
+- Modify: `app/components/posts/post_card.rb:67,118,123`
+- Modify: `app/controllers/blog_posts_controller.rb:40,65,79`
+- Modify: `app/jobs/reply_notification_job.rb:45-55` (`notification_path`)
+- Test: `test/controllers/blog_posts_controller_test.rb` (redirect expectations)
+
+**Interfaces:**
+- Consumes: `post_permalink_path(post)` from Task 1 (Components::Base); `user_profile_blog_post_path(username:, slug:)` route.
+
+- [ ] **Step 1: Update redirect expectations in blog_posts test (write failing test first)**
+
+In `test/controllers/blog_posts_controller_test.rb` change these assertions:
+
+- "publishing a new draft creates and publishes in one request" (line 74):
+  `assert_redirected_to user_profile_blog_post_url(username: published.user.username, slug: published)`
+- "publishes a complete draft" (line 132):
+  `assert_redirected_to user_profile_blog_post_url(username: @draft.user.username, slug: @draft)`
+- "updates a published blog post" (line 152):
+  `assert_redirected_to user_profile_blog_post_url(username: @published.user.username, slug: @published)`
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `mise x -- bin/rails test test/controllers/blog_posts_controller_test.rb -n "/publishing a new draft|publishes a complete draft|updates a published/"`
+Expected: FAIL (controller still redirects to `post_url`).
+
+- [ ] **Step 3: Update controller redirects**
+
+In `app/controllers/blog_posts_controller.rb` replace the three `redirect_to post_path(@post), ...` lines (40, 65, 79) with:
+
+```ruby
+      redirect_to user_profile_blog_post_path(username: @post.user.username, slug: @post), notice: t("posts.blog.published")
+```
+
+(line 40, `#create`)
+
+```ruby
+        format.html { redirect_to user_profile_blog_post_path(username: @post.user.username, slug: @post), notice: t("posts.blog.updated") }
+```
+
+(line 65, `#update`)
+
+```ruby
+    redirect_to user_profile_blog_post_path(username: @post.user.username, slug: @post), notice: t("posts.blog.published")
+```
+
+(line 79, `#publish`)
+
+- [ ] **Step 4: Update PostCard links**
+
+In `app/components/posts/post_card.rb` replace `post_path(@post)` at lines 67, 118, 123 with `post_permalink_path(@post)`. Example (line 118):
+
+```ruby
+      link_to @post.title, post_permalink_path(@post), class: "hover:text-accent-text transition-colors", data: { turbo_frame: "_top" }
+```
+
+Do the same for line 67 (timestamp link) and line 123 (read_more link).
+
+- [ ] **Step 5: Update reply notification path**
+
+In `app/jobs/reply_notification_job.rb`, replace the `else` branch of `notification_path` (line 52) so blog parents link to the new URL:
+
+```ruby
+  def notification_path(parent_post)
+    if parent_post.article.present?
+      Rails.application.routes.url_helpers.article_path(
+        parent_post.article,
+        anchor: "post_#{parent_post.id}"
+      )
+    elsif parent_post.blog?
+      Rails.application.routes.url_helpers.user_profile_blog_post_path(
+        username: parent_post.user.username, slug: parent_post
+      )
+    else
+      Rails.application.routes.url_helpers.post_path(parent_post)
+    end
+  end
+```
+
+- [ ] **Step 6: Run tests to verify pass**
+
+Run: `mise x -- bin/rails test test/controllers/blog_posts_controller_test.rb`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/components/posts/post_card.rb app/controllers/blog_posts_controller.rb app/jobs/reply_notification_job.rb test/controllers/blog_posts_controller_test.rb
+git commit -m "feat: route blog links/redirects through blog permalink"
+```
+
+---
+
+### Task 3: Public blog index (profiles#blog + ActivityTabs + BlogList rewrite + Show view)
+
+Flip the `blog` tab from owner-only management to a public list of published blog posts, reusing the `posts`-tab machinery.
+
+**Files:**
+- Modify: `app/controllers/profiles_controller.rb:7,98-108,154-164,191-193`
+- Modify: `app/components/profiles/activity_tabs.rb:14-20`
+- Rewrite: `app/views/profiles/blog_list.rb`
+- Modify: `app/views/profiles/show.rb:134-138`
+- Modify: `config/locales/{en,ja,ko}.yml` (add `profiles.blog_list.empty`)
+- Test: `test/controllers/profiles_controller_test.rb` (rework blog-tab tests)
+
+**Interfaces:**
+- Consumes: `post_permalink_path` (Task 1) via `PostCard` (Task 2); `Components::Posts::PostCard`, `Components::Pagination`, `Components::Profiles::ActivityTabs`.
+- Produces: `Views::Profiles::BlogList.new(user:, posts:, pagy:, liked_post_ids:, boosted_post_ids:, embedded:)` public reading list; `ProfilesController#blog` sets `@posts, @pagy, @liked_post_ids, @boosted_post_ids`.
+
+- [ ] **Step 1: Add the public empty-state i18n key**
+
+Under `profiles.blog_list:` in each locale add an `empty:` key.
+
+`config/locales/ko.yml` (after `trash_empty:` at line 337):
+```yaml
+      empty: 아직 발행한 블로그 글이 없습니다.
+```
+`config/locales/en.yml` (same `profiles.blog_list` block):
+```yaml
+      empty: No published blog posts yet.
+```
+`config/locales/ja.yml` (same block):
+```yaml
+      empty: まだ公開されたブログ記事がありません。
+```
+
+- [ ] **Step 2: Rewrite the blog-tab tests (write failing tests first)**
+
+In `test/controllers/profiles_controller_test.rb`:
+
+Delete these owner-only/management tests (they move to Task 4): "owner blog tab shows draft management entry", "owner blog draft entry offers a delete control", "blog drafts exclude trashed drafts", "owner blog trash section lists discarded blog posts", "owner blog trash section shows empty state when nothing discarded", and "blog tab requires the owner".
+
+Replace "owner blog tab lists published blog posts" and "blog tab is hidden from other users" with public-behavior tests:
+
+```ruby
+  test "public blog tab lists published blog posts to anyone" do
+    get user_profile_blog_url(username: users(:john).username)
+
+    assert_response :success
+    assert_includes response.body, posts(:blog_published).title
+    assert_select "a[href=?]", user_profile_blog_post_path(username: users(:john).username, slug: posts(:blog_published))
+  end
+
+  test "public blog tab excludes drafts and trash" do
+    posts(:blog_published).discard!
+
+    get user_profile_blog_url(username: users(:john).username)
+
+    assert_response :success
+    assert_not_includes response.body, posts(:blog_draft).title
+    assert_not_includes response.body, posts(:blog_published).title
+  end
+
+  test "blog tab is visible to other users" do
+    sign_in users(:jane)
+
+    get user_profile_posts_url(username: users(:john).username)
+
+    assert_response :success
+    assert_includes response.body, user_profile_blog_path(username: users(:john).username)
+  end
+```
+
+Keep "owner profile shows blog tab" as-is (still passes).
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `mise x -- bin/rails test test/controllers/profiles_controller_test.rb -n "/public blog tab|blog tab is visible/"`
+Expected: FAIL (blog action still redirects non-owners; BlogList still management markup).
+
+- [ ] **Step 4: Make `ProfilesController#blog` public**
+
+In `app/controllers/profiles_controller.rb`:
+
+Add `:blog` to the public actions on line 7:
+```ruby
+  skip_before_action :authenticate_user!, only: [ :show, :posts, :comments, :blog ]
+```
+
+Replace the `blog` action (lines 98-108) with:
+```ruby
+  def blog
+    @pagy, @posts = pagy(
+      @user.posts.published_blog.kept
+        .includes(:user, :federails_actor, :article, :tags)
+        .order(published_at: :desc)
+    )
+    @liked_post_ids = liked_ids_for_posts(@posts)
+    @boosted_post_ids = boosted_ids_for_posts(@posts)
+    render_activity_page(:blog)
+  end
+```
+
+Replace the `when :blog` branch in `render_activity_page` (lines 154-164) with:
+```ruby
+      when :blog
+        if turbo_frame_request?
+          render Views::Profiles::BlogList.new(
+            user: @user, posts: @posts, pagy: @pagy,
+            liked_post_ids: @liked_post_ids,
+            boosted_post_ids: @boosted_post_ids
+          )
+        else
+          render_show_with_activity(active_tab: :blog)
+        end
+```
+
+In `render_show_with_activity` remove the now-unused `blog_drafts:/blog_published:/blog_trash:` keyword args (lines 191-193).
+
+- [ ] **Step 5: Make the blog tab always visible**
+
+In `app/components/profiles/activity_tabs.rb`, move the blog tab line out of the `own_profile?` group. Replace lines 14-20 so `posts`, `comments`, `blog` are unconditional and only followers/following/likes/boosts stay guarded:
+
+```ruby
+        tab_link(t("profiles.activity_tabs.posts"), user_profile_posts_path(username: @user.username), :posts)
+        tab_link(t("profiles.activity_tabs.comments"), user_profile_comments_path(username: @user.username), :comments)
+        tab_link(t("profiles.activity_tabs.blog"), user_profile_blog_path(username: @user.username), :blog)
+        tab_link(t("profiles.activity_tabs.followers"), user_profile_followers_path(username: @user.username), :followers) if own_profile?
+        tab_link(t("profiles.activity_tabs.following"), user_profile_following_path(username: @user.username), :following) if own_profile?
+        tab_link(t("profiles.activity_tabs.likes"), user_profile_likes_path(username: @user.username), :likes) if own_profile?
+        tab_link(t("profiles.activity_tabs.boosts"), user_profile_boosts_path(username: @user.username), :boosts) if own_profile?
+```
+
+- [ ] **Step 6: Rewrite `Views::Profiles::BlogList` as a public reading list**
+
+Replace the entire contents of `app/views/profiles/blog_list.rb` with (mirrors `PostList`):
+
+```ruby
+# frozen_string_literal: true
+
+class Views::Profiles::BlogList < Views::Base
+  include Phlex::Rails::Helpers::ContentFor
+  include Phlex::Rails::Helpers::TurboFrameTag
+
+  def initialize(user:, posts:, pagy:, liked_post_ids: [], boosted_post_ids: [], embedded: false)
+    @user = user
+    @posts = posts
+    @pagy = pagy
+    @liked_post_ids = liked_post_ids
+    @boosted_post_ids = boosted_post_ids
+    @embedded = embedded
+  end
+
+  def view_template
+    if @embedded
+      list_content
+    else
+      content_for :title, "@#{@user.username} — #{t("profiles.activity_tabs.blog")}"
+      div(class: "max-w-2xl mx-auto py-10 px-4 sm:px-6") do
+        turbo_frame_tag("activity-list", class: "block") do
+          render Components::Profiles::ActivityTabs.new(user: @user, active_tab: :blog)
+          div(class: "mt-4") { list_content }
+        end
+      end
+    end
+  end
+
+  private
+
+  def list_content
+    if @posts.empty?
+      div(class: "text-center py-16 text-content-disabled") do
+        p { t("profiles.blog_list.empty") }
+      end
+    else
+      div(class: "flex flex-col gap-4") do
+        div(class: "flex flex-col gap-3") do
+          @posts.each do |post|
+            render Components::Posts::PostCard.new(
+              post: post,
+              liked: @liked_post_ids.include?(post.id),
+              boosted: @boosted_post_ids.include?(post.id)
+            )
+          end
+        end
+        render Components::Pagination.new(pagy: @pagy)
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 7: Update the Show view's embedded blog render**
+
+In `app/views/profiles/show.rb` replace the `when :blog` branch (lines 134-138) with:
+
+```ruby
+    when :blog
+      render Views::Profiles::BlogList.new(
+        user: @user, posts: @posts || [], pagy: @pagy,
+        liked_post_ids: @liked_post_ids,
+        boosted_post_ids: @boosted_post_ids, embedded: true
+      )
+```
+
+- [ ] **Step 8: Run tests to verify pass**
+
+Run: `mise x -- bin/rails test test/controllers/profiles_controller_test.rb`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/controllers/profiles_controller.rb app/components/profiles/activity_tabs.rb app/views/profiles/blog_list.rb app/views/profiles/show.rb config/locales/en.yml config/locales/ja.yml config/locales/ko.yml test/controllers/profiles_controller_test.rb
+git commit -m "feat: public blog index tab at /@user/blog"
+```
+
+---
+
+### Task 4: Blog management at `/account/blog`
+
+Move the drafts/published/trash management UI (removed from the profile tab in Task 3) to an authenticated `/account/blog` page, linked from account settings.
+
+**Files:**
+- Modify: `app/controllers/blog_posts_controller.rb` (add `#index`; redirects at lines 96,106)
+- Create: `app/views/blog_posts/index.rb`
+- Modify: `app/views/users/edit.rb` (add management link)
+- Modify: `config/locales/{en,ja,ko}.yml` (`posts.blog.manage_*`, `users.edit.blog_link`)
+- Test: `test/controllers/blog_posts_controller_test.rb` (index tests + redirect updates)
+
+**Interfaces:**
+- Consumes: `account_blog_path` route (Task 1); existing `edit_blog_post_path`, `blog_post_path`, `undiscard_blog_post_path`, `destroy_permanently_blog_post_path`, `post_permalink_path`.
+- Produces: `BlogPostsController#index` (sets `@drafts, @published, @trash` for `current_user`); `Views::BlogPosts::Index.new(user:, drafts:, published:, trash:)`.
+
+- [ ] **Step 1: Add management i18n keys**
+
+`config/locales/ko.yml` under `posts.blog:` (after `read_more:` line 282):
+```yaml
+      manage_title: 블로그 글 관리
+      manage_heading: 블로그 글 관리
+```
+under `users.edit:` (after `title:` line 379):
+```yaml
+      blog_link: 블로그 글 관리
+```
+`config/locales/en.yml` (`posts.blog`):
+```yaml
+      manage_title: Manage blog posts
+      manage_heading: Manage blog posts
+```
+`en.yml` (`users.edit`):
+```yaml
+      blog_link: Manage blog posts
+```
+`config/locales/ja.yml` (`posts.blog`):
+```yaml
+      manage_title: ブログ記事の管理
+      manage_heading: ブログ記事の管理
+```
+`ja.yml` (`users.edit`):
+```yaml
+      blog_link: ブログ記事の管理
+```
+
+- [ ] **Step 2: Write failing index + redirect tests**
+
+In `test/controllers/blog_posts_controller_test.rb` update the two redirect assertions:
+
+- "undiscard restores a discarded post for the owner" (line 230): `assert_redirected_to account_blog_url`
+- "destroy_permanently removes the row for the owner" (line 269): `assert_redirected_to account_blog_url`
+
+Then append the management tests (moved from the profiles test in Task 3):
+
+```ruby
+  test "index requires authentication" do
+    get account_blog_url
+
+    assert_redirected_to new_user_session_url
+  end
+
+  test "index shows the owner's drafts with edit and delete controls" do
+    sign_in @user
+
+    get account_blog_url
+
+    assert_response :success
+    assert_includes response.body, I18n.t("profiles.blog_list.drafts_heading")
+    assert_includes response.body, @draft.title
+    assert_select "a[href=?]", edit_blog_post_path(@draft)
+    assert_select "form[action=?]", blog_post_path(@draft)
+  end
+
+  test "index lists published posts linking to the public permalink" do
+    sign_in @user
+
+    get account_blog_url
+
+    assert_response :success
+    assert_includes response.body, @published.title
+    assert_select "a[href=?]", user_profile_blog_post_path(username: @user.username, slug: @published)
+  end
+
+  test "index drafts exclude trashed drafts and offer restore" do
+    sign_in @user
+    @draft.discard!
+
+    get account_blog_url
+
+    assert_response :success
+    assert_select "form[action=?]", undiscard_blog_post_path(@draft)
+    assert_select "a[href=?]", edit_blog_post_path(@draft), count: 0
+  end
+
+  test "index trash section lists discarded published posts with restore and destroy" do
+    sign_in @user
+    @published.discard!
+
+    get account_blog_url
+
+    assert_response :success
+    assert_select "form[action=?]", undiscard_blog_post_path(@published)
+    assert_select "form[action=?]", destroy_permanently_blog_post_path(@published)
+  end
+
+  test "index trash section shows empty state when nothing discarded" do
+    sign_in @user
+
+    get account_blog_url
+
+    assert_response :success
+    assert_includes response.body, I18n.t("profiles.blog_list.trash_empty")
+  end
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `mise x -- bin/rails test test/controllers/blog_posts_controller_test.rb -n "/index |undiscard restores|destroy_permanently removes/"`
+Expected: FAIL (`#index` action / view missing, redirects still to `user_profile_blog_url`).
+
+- [ ] **Step 4: Add `BlogPostsController#index` and update redirects**
+
+In `app/controllers/blog_posts_controller.rb`, add the action (after the `before_action`s; `#index` needs no `set_post`). Insert above `def new` (line 16):
+
+```ruby
+  def index
+    @drafts    = current_user.posts.blog.draft.kept.order(updated_at: :desc)
+    @published = current_user.posts.blog.published.kept.order(published_at: :desc)
+    @trash     = current_user.posts.blog.discarded.order(updated_at: :desc)
+    render Views::BlogPosts::Index.new(
+      user: current_user, drafts: @drafts, published: @published, trash: @trash
+    )
+  end
+```
+
+Change the two management redirects:
+- line 96 (`#undiscard`): `redirect_to account_blog_path, notice: t("posts.blog.restored")`
+- line 106 (`#destroy_permanently`): `redirect_to account_blog_path, notice: t("posts.blog.destroyed_permanently")`
+
+- [ ] **Step 5: Create the management view**
+
+Create `app/views/blog_posts/index.rb` with the management markup moved out of the old `BlogList` (drafts/published/trash rows + edit/delete/restore/destroy controls), rendered standalone (no ActivityTabs). The published row links to the public permalink:
+
+```ruby
+# frozen_string_literal: true
+
+class Views::BlogPosts::Index < Views::Base
+  include Phlex::Rails::Helpers::ContentFor
+  include Phlex::Rails::Helpers::LinkTo
+  include Phlex::Rails::Helpers::ButtonTo
+
+  def initialize(user:, drafts: [], published: [], trash: [])
+    @user = user
+    @drafts = drafts
+    @published = published
+    @trash = trash
+  end
+
+  def view_template
+    content_for :title, t("posts.blog.manage_title")
+    div(class: "max-w-2xl mx-auto py-10 px-4 sm:px-6") do
+      div(class: "mb-6 px-1") do
+        render RubyUI::Heading.new(level: 1, class: "text-2xl font-bold text-content tracking-tight") { t("posts.blog.manage_heading") }
+      end
+      div(class: "flex flex-col gap-8") do
+        drafts_section
+        published_section
+        trash_section
+      end
+    end
+  end
+
+  private
+
+  def drafts_section
+    section(class: "flex flex-col gap-3") do
+      h2(class: "text-sm font-semibold text-content") { t("profiles.blog_list.drafts_heading") }
+      drafts = @drafts.to_a
+      if drafts.empty?
+        empty_state(t("profiles.blog_list.drafts_empty"))
+      else
+        div(class: "flex flex-col gap-2") { drafts.each { |d| draft_row(d) } }
+      end
+    end
+  end
+
+  def published_section
+    section(class: "flex flex-col gap-3") do
+      h2(class: "text-sm font-semibold text-content") { t("profiles.blog_list.published_heading") }
+      published = @published.to_a
+      if published.empty?
+        empty_state(t("profiles.blog_list.published_empty"))
+      else
+        div(class: "flex flex-col gap-2") { published.each { |p| published_row(p) } }
+      end
+    end
+  end
+
+  def trash_section
+    section(class: "flex flex-col gap-3") do
+      h2(class: "text-sm font-semibold text-content") { t("profiles.blog_list.trash_heading") }
+      trash = @trash.to_a
+      if trash.empty?
+        empty_state(t("profiles.blog_list.trash_empty"))
+      else
+        div(class: "flex flex-col gap-2") { trash.each { |p| trash_row(p) } }
+      end
+    end
+  end
+
+  def empty_state(message)
+    div(class: "text-center py-8 text-content-disabled") { p { message } }
+  end
+
+  def draft_row(draft)
+    row do
+      link_to(edit_blog_post_path(draft),
+        class: "min-w-0 flex-1 truncate text-sm text-content hover:text-brand-text transition-colors",
+        data: { turbo_prefetch: false }) do
+        plain draft.title.presence || t("posts.blog.untitled_draft")
+      end
+      div(class: "flex items-center gap-2 shrink-0") do
+        button_to t("posts.blog.delete"), blog_post_path(draft),
+          method: :delete,
+          form: { data: { turbo_confirm: t("posts.blog.delete_confirm") } },
+          class: "text-xs font-medium text-content-muted hover:text-danger-text transition-colors cursor-pointer"
+      end
+    end
+  end
+
+  def published_row(post)
+    row do
+      link_to(post_permalink_path(post),
+        class: "min-w-0 flex-1 truncate text-sm text-content hover:text-brand-text transition-colors") do
+        plain post.title.presence || t("posts.blog.untitled_draft")
+      end
+      div(class: "flex items-center gap-2 shrink-0") do
+        link_to t("posts.blog.edit"), edit_blog_post_path(post),
+          class: "text-xs font-medium text-content-muted hover:text-content transition-colors",
+          data: { turbo_prefetch: false }
+        button_to t("posts.blog.delete"), blog_post_path(post),
+          method: :delete,
+          form: { data: { turbo_confirm: t("posts.blog.delete_confirm") } },
+          class: "text-xs font-medium text-content-muted hover:text-danger-text transition-colors cursor-pointer"
+      end
+    end
+  end
+
+  def trash_row(post)
+    row do
+      span(class: "min-w-0 flex-1 truncate text-sm text-content") do
+        plain post.title.presence || t("posts.blog.untitled_draft")
+      end
+      div(class: "flex items-center gap-2 shrink-0") do
+        button_to t("posts.blog.restore"), undiscard_blog_post_path(post),
+          method: :patch,
+          class: "text-xs font-medium text-content-muted hover:text-content transition-colors cursor-pointer"
+        button_to t("posts.blog.destroy_permanently"), destroy_permanently_blog_post_path(post),
+          method: :delete,
+          form: { data: { turbo_confirm: t("posts.blog.destroy_permanently_confirm") } },
+          class: "text-xs font-medium text-content-muted hover:text-danger-text transition-colors cursor-pointer"
+      end
+    end
+  end
+
+  def row(&block)
+    div(class: "flex items-center justify-between gap-3 rounded-md border border-border-muted bg-app/40 px-3 py-2", &block)
+  end
+end
+```
+
+- [ ] **Step 6: Add the management link to account settings**
+
+In `app/views/users/edit.rb`, add a link to `account_blog_path` after the form (inside the outer `div`, after `render Components::Users::Form...` on line 20):
+
+```ruby
+      div(class: "mt-6 px-1") do
+        link_to t("users.edit.blog_link"), account_blog_path,
+          class: "text-sm font-medium text-accent-text hover:underline"
+      end
+```
+
+Add `include Phlex::Rails::Helpers::LinkTo` to the class includes (after line 5).
+
+- [ ] **Step 7: Run tests to verify pass**
+
+Run: `mise x -- bin/rails test test/controllers/blog_posts_controller_test.rb`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/controllers/blog_posts_controller.rb app/views/blog_posts/index.rb app/views/users/edit.rb config/locales/en.yml config/locales/ja.yml config/locales/ko.yml test/controllers/blog_posts_controller_test.rb
+git commit -m "feat: move blog management to /account/blog"
+```
+
+---
+
+### Task 5: Update the blog system test end-to-end
+
+The system flow still assumes blog management/detail live at the old URLs; point it at the new public detail and `/account/blog`.
+
+**Files:**
+- Modify: `test/system/blog_posts_test.rb:53,61`
+
+**Interfaces:**
+- Consumes: `account_blog_path`, `user_profile_blog_post_path` (Tasks 1,4).
+
+- [ ] **Step 1: Point draft management at /account/blog**
+
+In `test/system/blog_posts_test.rb`, in "owner re-opens a draft, edits, and deletes a published post", change line 53:
+
+```ruby
+    visit account_blog_path
+```
+
+- [ ] **Step 2: Point the delete flow at the public blog detail**
+
+In the same test, change line 61:
+
+```ruby
+    visit user_profile_blog_post_path(username: @user.username, slug: posts(:blog_published))
+```
+
+- [ ] **Step 3: Run the system test**
+
+Run: `mise x -- bin/rails test:system test/system/blog_posts_test.rb`
+Expected: PASS (create/publish/read flow + draft-edit + delete flow all green).
+
+- [ ] **Step 4: Run the full affected suite**
+
+Run: `mise x -- bin/rails test test/controllers/posts_controller_test.rb test/controllers/blog_posts_controller_test.rb test/controllers/profiles_controller_test.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/system/blog_posts_test.rb
+git commit -m "test: update blog system flow for new blog URLs"
+```
+
+---
+
+## Notes / Rationale
+
+- **Why reuse `viewable?`:** the blog-detail branch fetches `user.posts.blog` (any status) then applies `viewable?`, preserving owner draft-preview at `/@user/blog/:slug` while 404ing drafts/discarded for everyone else — identical semantics to today's `/posts/:slug`.
+- **Why keep `post_permalink_path` on `Components::Base`:** both `PostCard` and `Views::BlogPosts::Index` need it, and route helpers are already mixed in there; the reply job can't use it and branches inline instead.
+- **Destructive `/posts/:slug` for blog:** accepted because only one blog post exists; no redirect/back-compat needed.

--- a/docs/superpowers/specs/2026-07-06-blog-public-index-design.md
+++ b/docs/superpowers/specs/2026-07-06-blog-public-index-design.md
@@ -126,10 +126,17 @@ blog 글을 계정별로 모아 보여주는 공개 페이지가 필요하다. U
   `posts:` + `pagy:` + liked/boosted ids 전달. `#blog`가 세팅하는 인스턴스 변수와
   일치시킨다.
 
-### 6b. `PostsController#show` — blog 상세 분기
+### 6b. blog 상세 조회
+
+> **최종 구조 (구현 시 반영):** 아래는 초기 설계로, blog 상세를 `PostsController#show`
+> 분기로 처리했다. 실제 구현은 blog 상세를 **`BlogsController#show`**로 분리하고
+> 공유 로직(`viewable?`/`build_thread`)을 `PostViewing` concern으로 추출했으며,
+> `PostsController#show`는 non-blog 전용으로 단순화했다. 라우팅/조회 규칙(username
+> 스코프, 전역 고유 slug, `where.not(post_type: :blog)`로 legacy 404)은 동일하다.
+> 자세한 최종 구조는 구현 계획의 Task 1b 참조.
 
 slug은 `friendly_id :random_slug`로 **전역 고유**하므로 username은 vanity/검증용이다.
-`show`의 조회를 라우트에 따라 분기한다:
+초기 설계(참고용)에서는 `PostsController#show`의 조회를 라우트에 따라 분기했다:
 
 ```ruby
 def show
@@ -186,8 +193,8 @@ end
 ### 8. i18n (en / ja / ko)
 
 - 기존 `profiles.activity_tabs.blog`, `profiles.blog_list.*` 재사용.
-- 신규: `account.blog.title`(관리 페이지 제목), 설정 페이지의 관리 링크 라벨.
-  3개 로케일 모두 추가.
+- 신규: `posts.blog.manage_title`/`posts.blog.manage_heading`(관리 페이지 제목/헤딩),
+  `users.edit.blog_link`(설정 페이지의 관리 링크 라벨). 3개 로케일 모두 추가.
 
 ## 테스트
 

--- a/docs/superpowers/specs/2026-07-06-blog-public-index-design.md
+++ b/docs/superpowers/specs/2026-07-06-blog-public-index-design.md
@@ -23,10 +23,16 @@ blog 글을 계정별로 모아 보여주는 공개 페이지가 필요하다. U
 
 - **`/@계정/blog`** = 해당 계정의 **공개** blog index. 발행된 blog 글만, 읽기 전용,
   카드 리스트. posts/comments 탭과 UX 일관.
+- **`/@계정/blog/:slug`** = blog 글 **상세 보기**. blog을 계정 아래로 완전히
+  네임스페이스화한다. 기존 `/posts/:slug`는 blog 글에 대해 **더 이상 열리지 않는다**
+  (파괴적 변경, C안). short 글만 `/posts/:slug` 유지.
 - 기존 **본인 전용 관리**(초안/발행/휴지통 + 수정/삭제/복원)는 **`/account/blog`**로
   이동. 진입점은 계정 설정 페이지(`/account/edit` → `Views::Users::Edit`)에 링크.
 - 기존 프로필 탭 인프라(`ActivityTabs`, `render_activity_page`)를 그대로 재사용해
   변경을 최소화한다. blog 전용 매거진 레이아웃은 **추후 리뉴얼** 대상(범위 밖).
+
+> **파괴적 변경 근거**: 현재 발행된 blog 글이 1개뿐이라 기존 `/posts/:slug` 링크
+> 보존(리다이렉트)이 불필요. 깔끔한 새 구조를 택한다.
 
 ## 비목표 (YAGNI)
 
@@ -39,6 +45,13 @@ blog 글을 계정별로 모아 보여주는 공개 페이지가 필요하다. U
 ### 1. 라우트 (`config/routes.rb`)
 
 - `get "/@:username/blog" → profiles#blog` **유지** (동작만 공개로 변경).
+- blog 상세 신규 추가 (index 라우트 바로 뒤, 더 구체적 경로):
+
+  ```ruby
+  get "/@:username/blog/:slug", to: "posts#show", as: :user_profile_blog_post,
+      format: false, constraints: { username: /[^\/]+/ }
+  ```
+
 - 관리 index 신규 추가 (인증 필요):
 
   ```ruby
@@ -101,15 +114,69 @@ blog 글을 계정별로 모아 보여주는 공개 페이지가 필요하다. U
   end
   ```
 
-- 리다이렉트 대상 변경 (`user_profile_blog_path` → `account_blog_path`):
-  - `undiscard`(복원) — 현재 96행
-  - `destroy_permanently`(영구삭제) — 현재 106행
+- 리다이렉트 대상 변경:
+  - `undiscard`(복원, 96행) / `destroy_permanently`(영구삭제, 106행):
+    `user_profile_blog_path` → `account_blog_path`
+  - `publish`(40행) / `update`(65행) / `publish`(79행):
+    `post_path(@post)` → `user_profile_blog_post_path` (6c 참조)
 
 ### 6. `Views::Profiles::Show` (`show.rb:134` `when :blog`)
 
 - blog 탭 인라인 렌더를 공개 BlogList 인터페이스에 맞춤: drafts/published/trash 대신
   `posts:` + `pagy:` + liked/boosted ids 전달. `#blog`가 세팅하는 인스턴스 변수와
   일치시킨다.
+
+### 6b. `PostsController#show` — blog 상세 분기
+
+slug은 `friendly_id :random_slug`로 **전역 고유**하므로 username은 vanity/검증용이다.
+`show`의 조회를 라우트에 따라 분기한다:
+
+```ruby
+def show
+  post =
+    if params[:username] # /@:username/blog/:slug
+      User.find_by!(username: params[:username])
+          .posts.published_blog.kept
+          .includes(POST_SHOW_INCLUDES)
+          .find_by!(slug: params[:slug])
+    else                 # /posts/:slug — blog 글은 여기서 열리지 않음
+      Post.where.not(post_type: :blog)
+          .includes(POST_SHOW_INCLUDES)
+          .find_by!(slug: params[:id])
+    end
+  # 이하 스레드 구성/렌더는 기존 그대로
+end
+```
+
+- 잘못된 username·미발행·discarded blog → `RecordNotFound`(404).
+- `/posts/:slug`에서 blog 글 → `where.not(post_type: :blog)`로 404 (C안 파괴적).
+- 기존 `.includes(...)` eager load는 상수 등으로 공유.
+
+### 6c. blog 글 링크 헬퍼
+
+blog 글은 새 URL, 그 외는 기존 `post_path`. 앱 레벨 URL 헬퍼 신설
+(예: `ApplicationHelper#post_permalink_path(post)`):
+
+```ruby
+def post_permalink_path(post)
+  if post.blog?
+    user_profile_blog_post_path(username: post.user.username, slug: post)
+  else
+    post_path(post)
+  end
+end
+```
+
+교체 대상:
+
+- `Components::Posts::PostCard` — `post_path(@post)` 3곳(67 타임스탬프, 118 blog
+  제목, 123 더보기) → `post_permalink_path(@post)`.
+- `BlogPostsController` 리다이렉트 3곳(40 publish, 65 update, 79 publish) →
+  `user_profile_blog_post_path(username: @post.user.username, slug: @post)`
+  (항상 blog이므로 직접 호출).
+- `Views::BlogPosts::Index`의 발행 글 미리보기 링크 → `post_permalink_path`.
+- `ReplyNotificationJob`(52행) — parent_post가 blog일 수 있음. 동일 분기의
+  `*_url` 버전 사용(알림은 절대 URL 필요).
 
 ### 7. 관리 진입점 — 계정 설정 페이지
 
@@ -129,6 +196,11 @@ blog 글을 계정별로 모아 보여주는 공개 페이지가 필요하다. U
 - **request spec `blog_posts#index` (관리)**: 인증 필요, current_user의
   drafts/published/trash만 노출. 항상 current_user 스코프라 타인 것 노출 불가.
 - **request spec 리다이렉트**: undiscard/destroy_permanently 후 `account_blog_path`로.
+  publish/update 후 `user_profile_blog_post_path`로.
+- **request spec blog 상세**: `/@user/blog/:slug`가 발행 blog 글 렌더. 미발행/타인
+  slug → 404. `/posts/:slug`에 blog slug → 404. short 글은 `/posts/:slug` 정상.
+- **헬퍼 spec**: `post_permalink_path` — blog은 `/@user/blog/:slug`, short은
+  `/posts/:slug`.
 - **뷰 spec**: 공개 `Views::Profiles::BlogList`가 PostCard로 발행 글을 렌더, 관리
   UI(수정/삭제) 미포함.
 
@@ -136,10 +208,14 @@ blog 글을 계정별로 모아 보여주는 공개 페이지가 필요하다. U
 
 | 파일 | 변경 |
 |------|------|
-| `config/routes.rb` | `account/blog` 라우트 추가 |
+| `config/routes.rb` | `/@:username/blog/:slug`, `account/blog` 라우트 추가 |
+| `app/controllers/posts_controller.rb` | `#show` blog/short 조회 분기 |
 | `app/controllers/profiles_controller.rb` | `#blog` 공개화, `render_activity_page(:blog)` 분기 인자 |
-| `app/controllers/blog_posts_controller.rb` | `#index` 추가, 2곳 리다이렉트 변경 |
+| `app/controllers/blog_posts_controller.rb` | `#index` 추가, 리다이렉트 5곳(publish/update/undiscard/destroy_permanently) 변경 |
+| `app/helpers/application_helper.rb` | `post_permalink_path` 신설 |
 | `app/components/profiles/activity_tabs.rb` | blog 탭 항상 노출 |
+| `app/components/posts/post_card.rb` | `post_path` → `post_permalink_path` 3곳 |
+| `app/jobs/reply_notification_job.rb` | blog parent 링크 분기 |
 | `app/views/profiles/blog_list.rb` | 공개 읽기 리스트로 재작성 |
 | `app/views/blog_posts/index.rb` | 신설 (관리 화면) |
 | `app/views/profiles/show.rb` | blog 탭 렌더 인자 변경 |

--- a/docs/superpowers/specs/2026-07-06-blog-public-index-design.md
+++ b/docs/superpowers/specs/2026-07-06-blog-public-index-design.md
@@ -1,0 +1,148 @@
+# 공개 Blog Index (`/@계정/blog`) + 관리 화면 분리 — 설계
+
+> 작성일: 2026-07-06
+
+## 배경 / 문제
+
+blog 글을 계정별로 모아 보여주는 공개 페이지가 필요하다. URL 구조는
+`/@계정/blog`가 해당 계정의 blog index 페이지가 된다.
+
+현재 상태:
+
+- `Post#post_type` enum: `short` / `blog` / `comment`. blog 글은 이미 별도 타입이다.
+- 개별 blog 글은 `/posts/:id`(`posts#show`)로 공개 표시된다.
+- `/@:username/blog` 라우트가 **이미 존재**하지만, `ProfilesController#blog`가
+  `current_user == @user`로 막힌 **본인 전용 관리 페이지**(초안/발행/휴지통 목록 +
+  수정/삭제/복원)로 쓰이고 있다.
+- `/@:username/posts`는 해당 계정의 short 글 목록(공개)이다.
+
+즉 원하는 URL이 이미 관리 페이지로 점유되어 있어, 공개 index로 전환하면서 관리
+화면을 다른 곳으로 옮겨야 한다.
+
+## 목표
+
+- **`/@계정/blog`** = 해당 계정의 **공개** blog index. 발행된 blog 글만, 읽기 전용,
+  카드 리스트. posts/comments 탭과 UX 일관.
+- 기존 **본인 전용 관리**(초안/발행/휴지통 + 수정/삭제/복원)는 **`/account/blog`**로
+  이동. 진입점은 계정 설정 페이지(`/account/edit` → `Views::Users::Edit`)에 링크.
+- 기존 프로필 탭 인프라(`ActivityTabs`, `render_activity_page`)를 그대로 재사용해
+  변경을 최소화한다. blog 전용 매거진 레이아웃은 **추후 리뉴얼** 대상(범위 밖).
+
+## 비목표 (YAGNI)
+
+- blog 전용 독립 레이아웃/디자인 리뉴얼.
+- 계정 설정 nav 전면 재편.
+- blog 글 자체(`posts#show`)의 표현 변경.
+
+## 설계
+
+### 1. 라우트 (`config/routes.rb`)
+
+- `get "/@:username/blog" → profiles#blog` **유지** (동작만 공개로 변경).
+- 관리 index 신규 추가 (인증 필요):
+
+  ```ruby
+  get "account/blog", to: "blog_posts#index", as: :account_blog
+  ```
+
+  `authenticate_user!`는 전역 before_action로 이미 적용된다.
+
+### 2. `ProfilesController#blog` — 공개화
+
+- `current_user == @user` 소유자 체크 **제거**.
+- 발행 + 미삭제(kept) blog 글만 로드. `#posts` 액션과 동일하게 pagy 적용:
+
+  ```ruby
+  @pagy, @posts = pagy(@user.posts.published_blog.kept.order(published_at: :desc))
+  ```
+
+  (pagy 헬퍼/변수 명은 기존 `#posts` 구현을 따른다.)
+- `@blog_drafts` / `@blog_published` / `@blog_trash` 로드 제거.
+- `render_activity_page(:blog)` 호출은 유지하되, blog 분기가 공개 BlogList를
+  렌더하도록 인자를 변경(아래 4, 6번).
+
+### 3. `Components::Profiles::ActivityTabs` (`activity_tabs.rb:20`)
+
+- blog 탭 링크를 `if own_profile?` 그룹에서 빼내어 **항상 노출**
+  (posts / comments 와 동일 라인). followers/following/likes/boosts는 그대로 소유자
+  전용 유지.
+
+### 4. 뷰 분리 — 공개 vs 관리
+
+**공개 — `Views::Profiles::BlogList` 재작성**
+
+- 발행 글을 읽기 카드로 표시. `Views::Profiles::PostList`를 미러링:
+  `Components::Posts::PostCard` + `Components::Pagination`.
+- 인자: `user:`, `posts:`, `pagy:`, `liked_post_ids:`, `boosted_post_ids:`,
+  `embedded: false`. (`PostList` 인터페이스와 정렬.)
+- `embedded`일 때 `activity-list` turbo-frame 내부 렌더 유지.
+- 수정/삭제/복원/휴지통 UI는 전부 제거(관리 뷰로 이동).
+
+**관리 — `Views::BlogPosts::Index` 신설**
+
+- 현재 `Views::Profiles::BlogList`의 관리 마크업(drafts/published/trash 섹션,
+  `draft_row`/`published_row`/`trash_row`, 수정/삭제/복원/영구삭제 버튼)을 이관.
+- ActivityTabs 없이 standalone 페이지. 자체 `content_for :title`과 헤더.
+- 기존 `edit_blog_post_path` / `blog_post_path` / `undiscard_blog_post_path` /
+  `destroy_permanently_blog_post_path` 링크는 그대로 사용.
+
+### 5. `BlogPostsController#index` 신설
+
+- current_user 기준으로 로드(기존 `profiles#blog` 로직 이관):
+
+  ```ruby
+  def index
+    @drafts    = current_user.posts.blog.draft.kept.order(updated_at: :desc)
+    @published = current_user.posts.blog.published.kept.order(published_at: :desc)
+    @trash     = current_user.posts.blog.discarded.order(updated_at: :desc)
+    render Views::BlogPosts::Index.new(
+      user: current_user, drafts: @drafts, published: @published, trash: @trash
+    )
+  end
+  ```
+
+- 리다이렉트 대상 변경 (`user_profile_blog_path` → `account_blog_path`):
+  - `undiscard`(복원) — 현재 96행
+  - `destroy_permanently`(영구삭제) — 현재 106행
+
+### 6. `Views::Profiles::Show` (`show.rb:134` `when :blog`)
+
+- blog 탭 인라인 렌더를 공개 BlogList 인터페이스에 맞춤: drafts/published/trash 대신
+  `posts:` + `pagy:` + liked/boosted ids 전달. `#blog`가 세팅하는 인스턴스 변수와
+  일치시킨다.
+
+### 7. 관리 진입점 — 계정 설정 페이지
+
+- `Views::Users::Edit`(`app/views/users/edit.rb`)에 "블로그 글 관리 →"
+  링크(`account_blog_path`) 추가.
+
+### 8. i18n (en / ja / ko)
+
+- 기존 `profiles.activity_tabs.blog`, `profiles.blog_list.*` 재사용.
+- 신규: `account.blog.title`(관리 페이지 제목), 설정 페이지의 관리 링크 라벨.
+  3개 로케일 모두 추가.
+
+## 테스트
+
+- **request spec `profiles#blog` (공개)**: 로그인 없이 접근 가능, 발행 글만 노출,
+  초안/휴지통 글은 노출 안 됨.
+- **request spec `blog_posts#index` (관리)**: 인증 필요, current_user의
+  drafts/published/trash만 노출. 항상 current_user 스코프라 타인 것 노출 불가.
+- **request spec 리다이렉트**: undiscard/destroy_permanently 후 `account_blog_path`로.
+- **뷰 spec**: 공개 `Views::Profiles::BlogList`가 PostCard로 발행 글을 렌더, 관리
+  UI(수정/삭제) 미포함.
+
+## 영향 파일 요약
+
+| 파일 | 변경 |
+|------|------|
+| `config/routes.rb` | `account/blog` 라우트 추가 |
+| `app/controllers/profiles_controller.rb` | `#blog` 공개화, `render_activity_page(:blog)` 분기 인자 |
+| `app/controllers/blog_posts_controller.rb` | `#index` 추가, 2곳 리다이렉트 변경 |
+| `app/components/profiles/activity_tabs.rb` | blog 탭 항상 노출 |
+| `app/views/profiles/blog_list.rb` | 공개 읽기 리스트로 재작성 |
+| `app/views/blog_posts/index.rb` | 신설 (관리 화면) |
+| `app/views/profiles/show.rb` | blog 탭 렌더 인자 변경 |
+| `app/views/users/edit.rb` | 관리 링크 추가 |
+| `config/locales/*.yml` | `account.blog.*` 등 추가 |
+| spec 파일들 | 위 테스트 |

--- a/sig/generated/controllers/blog_posts_controller.rbs
+++ b/sig/generated/controllers/blog_posts_controller.rbs
@@ -1,6 +1,8 @@
 # Generated from app/controllers/blog_posts_controller.rb with RBS::Inline
 
 class BlogPostsController < ApplicationController
+  def index: () -> untyped
+
   # Opens the editor for an unsaved draft. No row is created on entry — the
   # first autosave (or publish) persists it via #create.
   #

--- a/sig/generated/controllers/blogs_controller.rbs
+++ b/sig/generated/controllers/blogs_controller.rbs
@@ -1,0 +1,9 @@
+# Generated from app/controllers/blogs_controller.rb with RBS::Inline
+
+class BlogsController < ApplicationController
+  include PostViewing
+
+  # GET /@:username/blog/:slug — public blog detail. Scopes by username so the
+  # URL is canonical, but slugs are globally unique so this never ambiguates.
+  def show: () -> untyped
+end

--- a/sig/generated/controllers/posts_controller.rbs
+++ b/sig/generated/controllers/posts_controller.rbs
@@ -3,6 +3,8 @@
 class PostsController < ApplicationController
   include RateLimiting
 
+  include PostViewing
+
   def show: () -> untyped
 
   def create: () -> untyped
@@ -21,11 +23,6 @@ class PostsController < ApplicationController
 
   def load_article_comments: () -> untyped
 
-  # A post is publicly viewable when it is visible (published & kept). The owner
-  # may also preview their own non-published (draft) post. Discarded posts are
-  # never served here — the owner reaches them only via the profile trash tab.
-  def viewable?: (untyped post) -> untyped
-
   def article_comment_params: () -> untyped
 
   def post_params: () -> untyped
@@ -37,6 +34,4 @@ class PostsController < ApplicationController
   def mention_link_for: (untyped actor, untyped text) -> untyped
 
   def default_mention_text_for: (untyped actor) -> untyped
-
-  def build_thread: (untyped root) -> untyped
 end

--- a/sig/generated/models/concerns/posts/federation.rbs
+++ b/sig/generated/models/concerns/posts/federation.rbs
@@ -1,0 +1,18 @@
+# Generated from app/models/concerns/posts/federation.rb with RBS::Inline
+
+# ActivityPub serialization for Post: builds the outgoing Note object and the
+# canonical public URL advertised to remote servers.
+#
+# Kept out of Post itself so the model stays focused; the enums, scopes, and
+# federation callbacks remain on Post.
+module Posts::Federation
+  extend ActiveSupport::Concern
+
+  # : () -> Hash[String, untyped]
+  def to_activitypub_object: () -> Hash[String, untyped]
+
+  # Public, human-readable URL for this post. Blog posts live under the account
+  # namespace (/@user/blog/:slug); everything else at /posts/:slug.
+  # : () -> String
+  def public_url: () -> String
+end

--- a/sig/generated/models/post.rbs
+++ b/sig/generated/models/post.rbs
@@ -10,6 +10,8 @@ class Post < ApplicationRecord
 
   include Posts::Blog
 
+  include Posts::Federation
+
   include Discard::Model
 
   include Federails::DataEntity
@@ -23,9 +25,6 @@ class Post < ApplicationRecord
 
   # : () -> bool
   def should_federate?: () -> bool
-
-  # : () -> Hash[String, untyped]
-  def to_activitypub_object: () -> Hash[String, untyped]
 
   # : () -> Integer
   def likes_count: () -> Integer

--- a/test/controllers/blog_posts_controller_test.rb
+++ b/test/controllers/blog_posts_controller_test.rb
@@ -71,7 +71,7 @@ class BlogPostsControllerTest < ActionDispatch::IntegrationTest
 
     published = Post.blog.published.order(:id).last
 
-    assert_redirected_to post_url(published)
+    assert_redirected_to user_profile_blog_post_url(username: published.user.username, slug: published)
   end
 
   test "publishing a new draft without a title re-renders the editor" do
@@ -129,7 +129,7 @@ class BlogPostsControllerTest < ActionDispatch::IntegrationTest
     @draft.update!(title: "발행 제목", body: "<p>발행 본문</p>")
     patch publish_blog_post_url(@draft)
 
-    assert_redirected_to post_url(@draft)
+    assert_redirected_to user_profile_blog_post_url(username: @draft.user.username, slug: @draft)
     assert_predicate @draft.reload, :published?
     assert_not_nil @draft.published_at
   end
@@ -149,7 +149,7 @@ class BlogPostsControllerTest < ActionDispatch::IntegrationTest
       post: { title: "수정된 제목", body: "<p>수정된 본문</p>" }
     }
 
-    assert_redirected_to post_url(@published)
+    assert_redirected_to user_profile_blog_post_url(username: @published.user.username, slug: @published)
     assert_equal "수정된 제목", @published.reload.title
   end
 

--- a/test/controllers/blog_posts_controller_test.rb
+++ b/test/controllers/blog_posts_controller_test.rb
@@ -227,7 +227,7 @@ class BlogPostsControllerTest < ActionDispatch::IntegrationTest
 
     patch undiscard_blog_post_url(@published)
 
-    assert_redirected_to user_profile_blog_url(username: @user.username)
+    assert_redirected_to account_blog_url
     assert_not_predicate @published.reload, :discarded?
     assert_nil @published.deleted_at
   end
@@ -266,7 +266,7 @@ class BlogPostsControllerTest < ActionDispatch::IntegrationTest
 
     delete destroy_permanently_blog_post_url(@draft)
 
-    assert_redirected_to user_profile_blog_url(username: @user.username)
+    assert_redirected_to account_blog_url
     assert_not Post.where(id: @draft.id).exists?
   end
 
@@ -287,5 +287,64 @@ class BlogPostsControllerTest < ActionDispatch::IntegrationTest
     delete destroy_permanently_blog_post_url(@published)
 
     assert_predicate Post.where(id: @published.id), :exists?
+  end
+
+  test "index requires authentication" do
+    get account_blog_url
+
+    assert_redirected_to new_user_session_url
+  end
+
+  test "index shows the owner's drafts with edit and delete controls" do
+    sign_in @user
+
+    get account_blog_url
+
+    assert_response :success
+    assert_includes response.body, I18n.t("profiles.blog_list.drafts_heading")
+    assert_includes response.body, @draft.title
+    assert_select "a[href=?]", edit_blog_post_path(@draft)
+    assert_select "form[action=?]", blog_post_path(@draft)
+  end
+
+  test "index lists published posts linking to the public permalink" do
+    sign_in @user
+
+    get account_blog_url
+
+    assert_response :success
+    assert_includes response.body, @published.title
+    assert_select "a[href=?]", user_profile_blog_post_path(username: @user.username, slug: @published)
+  end
+
+  test "index drafts exclude trashed drafts and offer restore" do
+    sign_in @user
+    @draft.discard!
+
+    get account_blog_url
+
+    assert_response :success
+    assert_select "form[action=?]", undiscard_blog_post_path(@draft)
+    assert_select "a[href=?]", edit_blog_post_path(@draft), count: 0
+  end
+
+  test "index trash section lists discarded published posts with restore and destroy" do
+    sign_in @user
+    @published.discard!
+
+    get account_blog_url
+
+    assert_response :success
+    assert_select "form[action=?]", undiscard_blog_post_path(@published)
+    assert_select "form[action=?]", destroy_permanently_blog_post_path(@published)
+  end
+
+  test "index trash section shows empty state when nothing discarded" do
+    sign_in @user
+
+    get account_blog_url
+
+    assert_response :success
+    assert_includes response.body, I18n.t("profiles.blog_list.trash_empty")
   end
 end

--- a/test/controllers/blogs_controller_test.rb
+++ b/test/controllers/blogs_controller_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BlogsControllerTest < ActionDispatch::IntegrationTest
+  test "shows a published blog post with the reading layout to anyone" do
+    post = posts(:blog_published)
+
+    get user_profile_blog_post_url(username: post.user.username, slug: post)
+
+    assert_response :success
+    assert_includes response.body, post.title
+  end
+
+  test "draft blog post is not served to anonymous visitors" do
+    draft = posts(:blog_draft)
+
+    get user_profile_blog_post_url(username: draft.user.username, slug: draft)
+
+    assert_response :not_found
+  end
+
+  test "draft blog post is not served to a non-owner" do
+    draft = posts(:blog_draft)
+    sign_in users(:jane)
+
+    get user_profile_blog_post_url(username: draft.user.username, slug: draft)
+
+    assert_response :not_found
+  end
+
+  test "owner can preview their own draft blog post" do
+    draft = posts(:blog_draft)
+    sign_in draft.user
+
+    get user_profile_blog_post_url(username: draft.user.username, slug: draft)
+
+    assert_response :success
+  end
+
+  test "discarded blog post is not served publicly" do
+    post = posts(:blog_published)
+    post.discard!
+
+    get user_profile_blog_post_url(username: post.user.username, slug: post)
+
+    assert_response :not_found
+  end
+
+  test "correct slug under the wrong username is not found" do
+    post = posts(:blog_published)
+
+    get user_profile_blog_post_url(username: users(:jane).username, slug: post)
+
+    assert_response :not_found
+  end
+end

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -101,56 +101,20 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "unauthorized", JSON.parse(response.body)["error"]
   end
 
-  test "should show blog post with reading layout" do
-    post = posts(:blog_published)
-    get post_url(post)
+  test "blog post is not served at legacy /posts/:slug" do
+    blog = posts(:blog_published)
 
-    assert_response :success
-    assert_includes response.body, post.title
-    assert_includes response.body, "발행된 장문 본문"
-  end
-
-  test "published post is served to anyone" do
-    sign_out @user
-    post = posts(:blog_published)
-    get post_url(post)
-
-    assert_response :success
-    assert_includes response.body, post.title
-  end
-
-  test "draft is not served to anonymous visitors" do
-    sign_out @user
-    draft = posts(:blog_draft)
-    get post_url(draft)
+    get post_url(blog)
 
     assert_response :not_found
   end
 
-  test "draft is not served to a non-owner" do
-    sign_in users(:jane)
-    draft = posts(:blog_draft)
-    get post_url(draft)
+  test "short post is still served at /posts/:slug" do
+    short = posts(:short_with_article)
 
-    assert_response :not_found
-  end
-
-  test "owner can preview their own draft" do
-    draft = posts(:blog_draft)
-
-    assert_equal @user, draft.user
-    get post_url(draft)
+    get post_url(short)
 
     assert_response :success
-    assert_includes response.body, draft.title
-  end
-
-  test "discarded blog is not served publicly" do
-    post = posts(:blog_published)
-    post.discard!
-    get post_url(post)
-
-    assert_response :not_found
   end
 
   test "discarded comment does not appear in article comments" do

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -153,44 +153,22 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", edit_blog_post_path(posts(:blog_draft)), count: 0
   end
 
-  test "owner blog tab shows draft management entry" do
-    sign_in users(:john)
-    get user_profile_blog_url(username: users(:john).username)
-
-    assert_response :success
-    assert_includes response.body, I18n.t("profiles.blog_list.drafts_heading")
-    assert_includes response.body, posts(:blog_draft).title
-    assert_select "a[href=?]", edit_blog_post_path(posts(:blog_draft))
-  end
-
-  test "owner blog draft entry offers a delete control" do
-    sign_in users(:john)
-    get user_profile_blog_url(username: users(:john).username)
-
-    assert_response :success
-    assert_select "form[action=?]", blog_post_path(posts(:blog_draft))
-  end
-
-  test "blog drafts exclude trashed drafts" do
-    sign_in users(:john)
-    posts(:blog_draft).discard!
-
-    get user_profile_blog_url(username: users(:john).username)
-
-    assert_response :success
-    # 휴지통 복구 컨트롤로 노출되어야 한다 (작성 중 초안에는 없어야 함).
-    assert_select "form[action=?]", undiscard_blog_post_path(posts(:blog_draft))
-    assert_select "a[href=?]", edit_blog_post_path(posts(:blog_draft)), count: 0
-  end
-
-  test "owner blog tab lists published blog posts" do
-    sign_in users(:john)
-
+  test "public blog tab lists published blog posts to anyone" do
     get user_profile_blog_url(username: users(:john).username)
 
     assert_response :success
     assert_includes response.body, posts(:blog_published).title
-    assert_select "a[href=?]", post_path(posts(:blog_published))
+    assert_select "a[href=?]", user_profile_blog_post_path(username: users(:john).username, slug: posts(:blog_published))
+  end
+
+  test "public blog tab excludes drafts and trash" do
+    posts(:blog_published).discard!
+
+    get user_profile_blog_url(username: users(:john).username)
+
+    assert_response :success
+    assert_not_includes response.body, posts(:blog_draft).title
+    assert_not_includes response.body, posts(:blog_published).title
   end
 
   test "comments tab excludes discarded comments" do
@@ -202,35 +180,6 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes response.body, posts(:comment_post).body
   end
 
-  test "blog tab requires the owner" do
-    sign_in users(:jane)
-
-    get user_profile_blog_url(username: users(:john).username)
-
-    assert_redirected_to user_profile_base_path(username: users(:john).username)
-  end
-
-  test "owner blog trash section lists discarded blog posts" do
-    sign_in users(:john)
-    posts(:blog_published).discard!
-
-    get user_profile_blog_url(username: users(:john).username)
-
-    assert_response :success
-    assert_includes response.body, "발행된 긴 글"
-    assert_select "form[action=?]", undiscard_blog_post_path(posts(:blog_published))
-    assert_select "form[action=?]", destroy_permanently_blog_post_path(posts(:blog_published))
-  end
-
-  test "owner blog trash section shows empty state when nothing discarded" do
-    sign_in users(:john)
-
-    get user_profile_blog_url(username: users(:john).username)
-
-    assert_response :success
-    assert_includes response.body, I18n.t("profiles.blog_list.trash_empty")
-  end
-
   test "owner profile shows blog tab" do
     sign_in users(:john)
 
@@ -240,12 +189,12 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, I18n.t("profiles.activity_tabs.blog")
   end
 
-  test "blog tab is hidden from other users" do
+  test "blog tab is visible to other users" do
     sign_in users(:jane)
 
     get user_profile_posts_url(username: users(:john).username)
 
     assert_response :success
-    assert_not_includes response.body, user_profile_blog_path(username: users(:john).username)
+    assert_includes response.body, user_profile_blog_path(username: users(:john).username)
   end
 end

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -63,6 +63,7 @@ short_with_article:
   article: ruby_article
   post_type: 0
   status: 1
+  slug: "lf-short-fixture"
   lft: 13
   rgt: 14
   depth: 0

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -583,7 +583,7 @@ class PostTest < ActiveSupport::TestCase
     assert_equal post, captured[:record]
     assert_equal post.blog_summary, captured[:content]
     assert_equal post.title, captured[:name]
-    assert_equal Rails.application.routes.url_helpers.post_url(post), captured[:custom]["url"]
+    assert_equal Rails.application.routes.url_helpers.user_profile_blog_post_url(username: post.user.username, slug: post), captured[:custom]["url"]
   end
 
   test "to_activitypub_object의 실제 발행 Note에 장문 제목이 채워진다" do
@@ -600,7 +600,7 @@ class PostTest < ActiveSupport::TestCase
 
     assert_equal post.title, note["name"]
     assert_equal post.blog_summary, note["content"]
-    assert_equal Rails.application.routes.url_helpers.post_url(post), note["url"]
+    assert_equal Rails.application.routes.url_helpers.user_profile_blog_post_url(username: post.user.username, slug: post), note["url"]
   end
 
   test "to_activitypub_object는 단문 본문 전체 발행을 유지한다" do

--- a/test/system/blog_posts_test.rb
+++ b/test/system/blog_posts_test.rb
@@ -50,7 +50,7 @@ class BlogPostsTest < ApplicationSystemTestCase
     # 이 영역은 프로필의 "activity-list" 터보 프레임 안에 있지만, 링크에
     # data-turbo-frame="_top" 이 있어 클릭 시 전체 페이지 네비게이션으로
     # 편집기가 정상적으로 열린다.
-    visit user_profile_blog_path(username: @user.username)
+    visit account_blog_path
     click_link draft.title
 
     assert_text I18n.t("posts.blog.edit_heading")
@@ -58,7 +58,7 @@ class BlogPostsTest < ApplicationSystemTestCase
     assert_text "초안 본문입니다."
 
     # 발행 장문을 원문 페이지에서 삭제(soft discard)하면 목록에서 사라진다.
-    visit post_path(posts(:blog_published))
+    visit user_profile_blog_post_path(username: @user.username, slug: posts(:blog_published))
     accept_confirm { click_button I18n.t("posts.blog.delete") }
 
     # 삭제 후 프로필 목록에서 해당 발행 장문이 더 이상 보이지 않는다.


### PR DESCRIPTION
## 개요

블로그 글을 계정별 전용 URL로 모아 보여줍니다.

- **`/@계정/blog`** — 해당 계정의 **공개** 블로그 index (발행 글 목록, 읽기 전용, 프로필 탭 재사용)
- **`/@계정/blog/:slug`** — 블로그 글 상세 (`BlogsController#show`)
- **`/account/blog`** — 초안/발행/휴지통 **관리** 화면 (인증 필요), 계정 설정에서 링크

## 주요 변경

- `BlogsController#show` 신설 + `PostViewing` concern으로 `viewable?`/`build_thread` 공유. `PostsController#show`는 non-blog 전용으로 단순화
- 프로필 `blog` 탭이 본인 전용 관리 → **공개 발행 목록**으로 전환, 항상 노출. `Views::Profiles::BlogList`를 PostCard 읽기 리스트로 재작성
- 블로그 관리(초안/휴지통)는 `BlogPostsController#index` + `Views::BlogPosts::Index`로 이전
- `post_permalink_path` 헬퍼 도입 — PostCard·컨트롤러 리다이렉트·reply 알림·ActivityPub 출력이 모두 새 블로그 URL을 가리킴 (`Posts::Federation` concern)

## ⚠️ 파괴적 변경

기존 `/posts/:slug`는 **블로그 글에 대해 404**입니다 (short/comment 글은 유지). 현재 발행된 블로그 글이 1개뿐이라 리다이렉트 없이 진행했습니다.

## 테스트

- 모델 + 컨트롤러: 573 runs, 0 failures
- 시스템: 3 runs, 0 failures
- 공개 접근/초안·휴지통 제외/교차 사용자 격리/legacy 404/permalink 라우팅/ActivityPub URL 갱신 커버

설계·계획 문서: `docs/superpowers/{specs,plans}/2026-07-06-blog-public-index*.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 블로그 글을 위한 공개 상세 페이지와 관리 화면이 추가되었습니다.
  * 프로필의 블로그 탭이 공개 발행 글 목록으로 바뀌고, 페이지네이션이 지원됩니다.
  * 사용자 설정 화면에서 블로그 관리로 이동하는 링크가 추가되었습니다.

* **Bug Fixes**
  * 블로그 글 링크와 알림이 새 블로그 전용 주소로 연결되도록 개선했습니다.
  * 초안, 휴지통, 비공개 글은 공개 화면에서 보이지 않도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->