### PR TITLE
Cut unused JS/CSS off the critical path (lazy controllers, lexxy, lightgallery)

### DIFF
--- a/app/components/layout.rb
+++ b/app/components/layout.rb
@@ -11,6 +11,7 @@ class Components::Layout < Components::Base
     doctype
     html(lang: I18n.locale, class: "light theme-light") do
       head do
+        render_asset_preconnect
         render_theme_init_script
         render_analytics_scripts
         render_meta_tags
@@ -163,18 +164,32 @@ class Components::Layout < Components::Base
     link(rel: "icon", type: "image/png", sizes: "16x16", href: "/favicon-16x16.png")
   end
 
+  # asset_host(예: assets.ruby-news.dev)는 cross-origin이라, 렌더 차단
+  # app.css와 LCP 이미지 첫 요청 전에 DNS+TLS 연결을 예열한다.
+  # asset_host 람다를 그대로 호출해 호스트 판별 로직(단일 진실원)을 재사용한다.
+  # ruby-news.jp(same-origin)나 개발환경(asset_host nil)에서는 아무것도 렌더하지 않는다.
+  def render_asset_preconnect
+    resolver = ActionController::Base.asset_host
+    return unless resolver.respond_to?(:call)
+
+    origin = resolver.call(nil, view_context.request)
+    return if origin.blank?
+
+    link(rel: "preconnect", href: origin)
+    link(rel: "dns-prefetch", href: origin)
+  rescue StandardError
+    nil
+  end
+
   def render_google_fonts
+    href = "https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap"
     link(rel: "preconnect", href: "https://fonts.googleapis.com")
     link(rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: true)
-    link(
-      rel: "preload",
-      href: "https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap",
-      as: "style"
-    )
-    link(
-      rel: "stylesheet",
-      href: "https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap"
-    )
+    # 폰트 CSS를 렌더 차단에서 제외한다: preload로 받아온 뒤 onload에서 rel을
+    # stylesheet로 전환하고, display=swap으로 로드 중 텍스트가 숨지 않게 한다.
+    # Phlex는 onload 인라인 핸들러를 막으므로 정적 문자열을 raw로 렌더한다.
+    raw(%(<link rel="preload" href="#{href.gsub('&', '&amp;')}" as="style" onload="this.onload=null;this.rel='stylesheet'">).html_safe)
+    noscript { link(rel: "stylesheet", href: href) }
   end
 
   def render_schema_org

--- a/app/components/layout.rb
+++ b/app/components/layout.rb
@@ -22,7 +22,8 @@ class Components::Layout < Components::Base
         render_google_fonts
         stylesheet_link_tag :app, data_turbo_track: "reload"
         stylesheet_link_tag "lexxy", data_turbo_track: "reload"
-        stylesheet_link_tag "vendor/lightgallery", data_turbo_track: "reload"
+        # vendor/lightgallery.css는 렌더 차단을 피하려고 head에서 제거했다.
+        # lightbox 컨트롤러가 연결될 때(=갤러리가 있는 페이지)만 주입한다.
         javascript_importmap_tags
         render_schema_org
       end

--- a/app/components/layout.rb
+++ b/app/components/layout.rb
@@ -165,20 +165,32 @@ class Components::Layout < Components::Base
   end
 
   # asset_host(예: assets.ruby-news.dev)는 cross-origin이라, 렌더 차단
-  # app.css와 LCP 이미지 첫 요청 전에 DNS+TLS 연결을 예열한다.
-  # asset_host 람다를 그대로 호출해 호스트 판별 로직(단일 진실원)을 재사용한다.
-  # ruby-news.jp(same-origin)나 개발환경(asset_host nil)에서는 아무것도 렌더하지 않는다.
+  # app.css와 preload되는 코어 JS 모듈의 첫 요청 전에 DNS+TLS 연결을 예열한다.
+  # asset_host 설정(람다 또는 문자열)을 그대로 사용해 호스트 판별 로직(단일 진실원)을
+  # 재사용한다. ruby-news.jp(same-origin)나 개발환경(asset_host nil)에서는 아무것도
+  # 렌더하지 않는다.
   def render_asset_preconnect
-    resolver = ActionController::Base.asset_host
-    return unless resolver.respond_to?(:call)
-
-    origin = resolver.call(nil, view_context.request)
+    origin = asset_preconnect_origin
     return if origin.blank?
 
+    # asset_host는 CSS/이미지(비-CORS)와 ES 모듈(CORS)을 모두 서빙하므로
+    # 두 연결 풀을 각각 예열한다(fonts.googleapis/gstatic 패턴과 동일).
     link(rel: "preconnect", href: origin)
-    link(rel: "dns-prefetch", href: origin)
-  rescue StandardError
+    link(rel: "preconnect", href: origin, crossorigin: true)
+  rescue StandardError => e
+    # preconnect는 성능 최적화일 뿐이라 페이지 렌더는 계속하되,
+    # "no silent failures" 원칙에 따라 삼키지 않고 신호를 남긴다.
+    Rails.logger.error("render_asset_preconnect failed: #{e.class} - #{e.message}")
+    Sentry.capture_exception(e) if defined?(Sentry)
     nil
+  end
+
+  # asset_host 설정을 그대로 해석해 preconnect 대상 origin을 반환한다(단일 진실원).
+  # 람다(request 기반)와 문자열 설정을 모두 지원하고, 미설정(dev)이면 nil.
+  #: (?untyped request) -> String?
+  def asset_preconnect_origin(request = view_context.request)
+    host = ActionController::Base.asset_host
+    host.respond_to?(:call) ? host.call(nil, request) : host
   end
 
   def render_google_fonts
@@ -188,7 +200,7 @@ class Components::Layout < Components::Base
     # 폰트 CSS를 렌더 차단에서 제외한다: preload로 받아온 뒤 onload에서 rel을
     # stylesheet로 전환하고, display=swap으로 로드 중 텍스트가 숨지 않게 한다.
     # Phlex는 onload 인라인 핸들러를 막으므로 정적 문자열을 raw로 렌더한다.
-    raw(%(<link rel="preload" href="#{href.gsub('&', '&amp;')}" as="style" onload="this.onload=null;this.rel='stylesheet'">).html_safe)
+    raw(%(<link rel="preload" href="#{CGI.escapeHTML(href)}" as="style" onload="this.onload=null;this.rel='stylesheet'">).html_safe)
     noscript { link(rel: "stylesheet", href: href) }
   end
 

--- a/app/components/posts/post_card.rb
+++ b/app/components/posts/post_card.rb
@@ -142,7 +142,7 @@ class Components::Posts::PostCard < Components::Base
 
     grid_class = attachments.size == 1 ? "grid-cols-1" : "grid-cols-2"
     div(
-      data: { controller: "lightbox" },
+      data: { controller: "lightbox", lightbox_stylesheet: helpers.asset_path("vendor/lightgallery.css") },
       class: "grid #{grid_class} gap-1 rounded-xl overflow-hidden mt-2"
     ) do
       attachments.each do |attachment|

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -6,6 +6,14 @@ import "controllers";
 // lexxy(리치텍스트 에디터, ~250KB)는 에디터가 있는 페이지에서만 동적 로드한다.
 // 서버가 <lexxy-editor> 커스텀 엘리먼트를 렌더하므로 존재 여부로 판단하며,
 // dynamic import는 모듈 캐시를 타서 Turbo 네비게이션마다 재요청하지 않는다.
+// (turbo:load는 첫 로드와 Turbo 네비게이션 모두에서 발생하므로 두 경로를 모두 커버)
 document.addEventListener("turbo:load", () => {
-  if (document.querySelector("lexxy-editor")) import("lexxy");
+  if (!document.querySelector("lexxy-editor")) return;
+
+  // 로드 실패를 삼키지 않는다: 조용히 죽으면 에디터가 동작하지 않으므로
+  // 콘솔/Sentry에 신호를 남긴다.
+  import("lexxy").catch((error) => {
+    console.error("Failed to load lexxy editor:", error);
+    window.Sentry?.captureException?.(error);
+  });
 });

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,11 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails";
 import "@rails/activestorage";
-import "lexxy";
 import "controllers";
+
+// lexxy(리치텍스트 에디터, ~250KB)는 에디터가 있는 페이지에서만 동적 로드한다.
+// 서버가 <lexxy-editor> 커스텀 엘리먼트를 렌더하므로 존재 여부로 판단하며,
+// dynamic import는 모듈 캐시를 타서 Turbo 네비게이션마다 재요청하지 않는다.
+document.addEventListener("turbo:load", () => {
+  if (document.querySelector("lexxy-editor")) import("lexxy");
+});

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,6 +1,14 @@
 // Import and register all your controllers from the importmap via controllers/**/*_controller
 import { application } from "controllers/application"
 import { lazyLoadControllersFrom } from "@hotwired/stimulus-loading"
-// lazy 로딩: 각 컨트롤러 모듈(과 chart.js/embla/lightgallery 등 무거운 의존성)은
+import PageLoaderController from "controllers/page_loader_controller"
+
+// page-loader는 <body>에 항상 붙어 turbo:before-visit로 첫 네비게이션 스피너를
+// 구동한다. lazy면 DOM ready~connect 사이 첫 네비에서 스피너가 누락될 수 있어
+// eager로 등록한다(@hotwired/stimulus만 의존, 가벼움). 이미 등록되어 있으면
+// lazyLoadControllersFrom가 중복 로드하지 않는다.
+application.register("page-loader", PageLoaderController)
+
+// lazy 로딩: 나머지 컨트롤러 모듈(과 chart.js/embla/lightgallery 등 무거운 의존성)은
 // 페이지에 해당 data-controller 요소가 나타날 때만 fetch된다.
 lazyLoadControllersFrom("controllers", application)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,4 +1,6 @@
 // Import and register all your controllers from the importmap via controllers/**/*_controller
 import { application } from "controllers/application"
-import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
-eagerLoadControllersFrom("controllers", application)
+import { lazyLoadControllersFrom } from "@hotwired/stimulus-loading"
+// lazy 로딩: 각 컨트롤러 모듈(과 chart.js/embla/lightgallery 등 무거운 의존성)은
+// 페이지에 해당 data-controller 요소가 나타날 때만 fetch된다.
+lazyLoadControllersFrom("controllers", application)

--- a/app/javascript/controllers/lightbox_controller.js
+++ b/app/javascript/controllers/lightbox_controller.js
@@ -16,6 +16,13 @@ export default class extends Lightbox {
     link.rel = "stylesheet";
     link.href = href;
     link.dataset.lightgalleryCss = "";
+    // 로드 실패를 삼키지 않는다: 마커 link를 제거해 이후 네비게이션에서
+    // 재시도할 수 있게 하고(안 그러면 dedup 가드가 영구 차단), 신호를 남긴다.
+    link.onerror = () => {
+      console.error("Failed to load lightgallery stylesheet:", href);
+      window.Sentry?.captureException?.(new Error(`lightgallery CSS load failed: ${href}`));
+      link.remove();
+    };
     document.head.appendChild(link);
   }
 

--- a/app/javascript/controllers/lightbox_controller.js
+++ b/app/javascript/controllers/lightbox_controller.js
@@ -1,6 +1,24 @@
 import Lightbox from "@stimulus-components/lightbox";
 
 export default class extends Lightbox {
+  connect() {
+    this.#ensureStylesheet();
+    super.connect();
+  }
+
+  // lightgallery.css(~16KB)는 레이아웃에서 전역 로드하지 않고
+  // 갤러리가 있는 페이지에서만, 한 번만 주입한다.
+  #ensureStylesheet() {
+    const href = this.element.dataset.lightboxStylesheet;
+    if (!href || document.querySelector("link[data-lightgallery-css]")) return;
+
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = href;
+    link.dataset.lightgalleryCss = "";
+    document.head.appendChild(link);
+  }
+
   get defaultOptions() {
     return {
       selector: "a",

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -8,7 +8,9 @@ pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 # (preload하면 모든 컨트롤러 파일이 즉시 다운로드되고, modulepreload가
 #  chart.js 같은 무거운 의존성까지 재귀적으로 끌어올 수 있다.)
 pin_all_from "app/javascript/controllers", under: "controllers", preload: false
-pin_all_from "app/javascript/utils", under: "utils"
+# utils(form_helpers)의 소비자(post_form/reply_form 컨트롤러)가 모두 lazy이므로
+# 함께 preload에서 제외한다.
+pin_all_from "app/javascript/utils", under: "utils", preload: false
 # 아래 라이브러리들은 lazy 로드되는 Stimulus 컨트롤러(또는 조건부 lexxy)에서만
 # 쓰인다. importmap-rails의 pin 기본값은 preload: true라서, 그대로 두면
 # <link rel="modulepreload">로 전 페이지에서 즉시 다운로드된다. preload: false로

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -4,17 +4,24 @@ pin "application"
 pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
-pin_all_from "app/javascript/controllers", under: "controllers"
+# 컨트롤러는 lazyLoadControllersFrom로 지연 로드하므로 preload하지 않는다.
+# (preload하면 모든 컨트롤러 파일이 즉시 다운로드되고, modulepreload가
+#  chart.js 같은 무거운 의존성까지 재귀적으로 끌어올 수 있다.)
+pin_all_from "app/javascript/controllers", under: "controllers", preload: false
 pin_all_from "app/javascript/utils", under: "utils"
-pin "@floating-ui/dom", to: "@floating-ui--dom.js" # @1.7.6
-pin "@floating-ui/core", to: "@floating-ui--core.js" # @1.7.5
-pin "@floating-ui/utils", to: "@floating-ui--utils.js" # @0.2.11
-pin "@floating-ui/utils/dom", to: "@floating-ui--utils--dom.js" # @0.2.11
-pin "embla-carousel" # @8.6.0
-pin "lexxy", to: "lexxy.js"
+# 아래 라이브러리들은 lazy 로드되는 Stimulus 컨트롤러(또는 조건부 lexxy)에서만
+# 쓰인다. importmap-rails의 pin 기본값은 preload: true라서, 그대로 두면
+# <link rel="modulepreload">로 전 페이지에서 즉시 다운로드된다. preload: false로
+# 명시해 실제로 필요한 페이지에서 동적 import될 때만 fetch되게 한다.
+pin "@floating-ui/dom", to: "@floating-ui--dom.js", preload: false # @1.7.6
+pin "@floating-ui/core", to: "@floating-ui--core.js", preload: false # @1.7.5
+pin "@floating-ui/utils", to: "@floating-ui--utils.js", preload: false # @0.2.11
+pin "@floating-ui/utils/dom", to: "@floating-ui--utils--dom.js", preload: false # @0.2.11
+pin "embla-carousel", preload: false # @8.6.0
+pin "lexxy", to: "lexxy.js", preload: false
 pin "@rails/activestorage", to: "activestorage.esm.js"
-pin "chart.js" # @4.5.1
-pin "@kurkle/color", to: "@kurkle--color.js" # @0.3.4
-pin "@stimulus-components/lightbox", to: "@stimulus-components--lightbox.js" # @4.0.0
-pin "lightgallery" # @2.9.0
-pin "@stimulus-components/character-counter", to: "@stimulus-components--character-counter.js" # @5.1.0
+pin "chart.js", preload: false # @4.5.1
+pin "@kurkle/color", to: "@kurkle--color.js", preload: false # @0.3.4
+pin "@stimulus-components/lightbox", to: "@stimulus-components--lightbox.js", preload: false # @4.0.0
+pin "lightgallery", preload: false # @2.9.0
+pin "@stimulus-components/character-counter", to: "@stimulus-components--character-counter.js", preload: false # @5.1.0

--- a/test/components/layout_asset_preconnect_test.rb
+++ b/test/components/layout_asset_preconnect_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LayoutAssetPreconnectTest < ActiveSupport::TestCase
+  def setup
+    @layout = Components::Layout.allocate
+    @original_asset_host = ActionController::Base.asset_host
+  end
+
+  def teardown
+    ActionController::Base.asset_host = @original_asset_host
+  end
+
+  def request_for(host)
+    Struct.new(:host).new(host)
+  end
+
+  test "람다형 asset_host는 request 호스트로 origin을 판별한다" do
+    ActionController::Base.asset_host =
+      ->(_source, request = nil) { request&.host == "ruby-news.jp" ? nil : "https://assets.ruby-news.dev" }
+
+    assert_equal "https://assets.ruby-news.dev", @layout.send(:asset_preconnect_origin, request_for("ruby-news.dev"))
+    assert_nil @layout.send(:asset_preconnect_origin, request_for("ruby-news.jp"))
+  end
+
+  test "문자열형 asset_host도 그대로 origin으로 반환한다" do
+    ActionController::Base.asset_host = "https://cdn.example.com"
+
+    assert_equal "https://cdn.example.com", @layout.send(:asset_preconnect_origin, request_for("ruby-news.dev"))
+  end
+
+  test "asset_host 미설정(개발환경)이면 nil이라 preconnect를 렌더하지 않는다" do
+    ActionController::Base.asset_host = nil
+
+    assert_nil @layout.send(:asset_preconnect_origin, request_for("ruby-news.dev"))
+  end
+end


### PR DESCRIPTION
## 배경

PageSpeed Insights(모바일): **미사용 JS ~389KiB**, **FCP 8.3s / LCP 10.5s**, TBT 40ms(우수). → JS *실행*이 아니라 **불필요한 리소스의 전 페이지 로드 + 렌더 차단**이 문제.

## 변경 (5가지)

### 1. Stimulus 컨트롤러 lazy 로딩
`eagerLoadControllersFrom` → `lazyLoadControllersFrom`. 컨트롤러가 해당 `data-controller` 요소가 있는 페이지에서만 로드.

### 2. lexxy 에디터 JS 지연 로딩 (~250KB)
`application.js`의 전역 `import "lexxy"` 제거. `<lexxy-editor>` 엘리먼트가 있을 때만 동적 import.

### 3. import map preload 차단 ⭐ (1·2를 실제로 완성)
`importmap-rails`의 `pin` 기본값이 `preload: true`라, lazy 로딩/lexxy 지연 후에도 chart.js·lightgallery·embla·floating-ui·**lexxy** 등이 `<link rel="modulepreload">`로 **전 페이지에서 여전히 다운로드**되고 있었음. lazy 전용 pin과 `pin_all_from controllers`에 `preload: false` 명시. **preload 모듈 46 → 6개(코어 런타임만)**, 매핑 유지로 동적 import는 정상.

### 4. lightgallery.css 조건부 로딩 (~16KB)
head의 렌더 차단 `<link>` 제거 → lightbox 컨트롤러가 갤러리 렌더 시 핑거프린트 경로로 1회 주입.

### 5. 초기 렌더 경로 (FCP/LCP)
- **asset_host preconnect**: 렌더 차단 app.css·LCP 이미지가 cross-origin `assets.ruby-news.dev`에서 오므로 DNS+TLS 예열. asset_host 람다 재사용(ruby-news.jp/dev는 미출력).
- **Google Fonts 비동기화**: Noto Sans KR을 렌더 차단에서 제외(preload+onload rel 전환, noscript fallback, display=swap). Phlex가 인라인 onload를 막아 `raw()`로 렌더.

> lexxy.css(67B)·app.css(above-the-fold 필수)는 head 유지. 캐시 정책은 이미 올바름(`/assets` immutable 1년).

## 검증

- **blog_posts·boosts 시스템 테스트(실제 브라우저)** 통과: lazy on-demand 로딩·에디터·라이트박스 회귀 없음.
- `preloaded_module_paths` 46→6, 무거운 라이브러리·lexxy 제거 확인. importmap 매핑 유지.
- layout/posts 컨트롤러·컴포넌트 테스트 통과. asset_host 람다(dev→assets, jp→nil)·폰트/preconnect 마크업 렌더 확인.

## 검증 요청 (런타임은 자동 테스트 범위 밖)
병합 전 스모크 테스트 권장: 차트, 캐러셀, 라이트박스(이미지 클릭), 드롭다운/다이얼로그/팝오버, 무한 스크롤, 푸시 알림, 에디터(lexxy) 입력, 폰트 적용(FOUT).

## 후속 (이 PR 범위 밖)
- `/v9bc/`(167KiB) — 앱 소스에 없는 서드파티/엣지 주입 추정, 별도 조사.
- JS minify(53KiB) — Propshaft는 minify 안 함(vendor는 이미 minified).
- app.css critical CSS 인라인 — Tailwind v4 특성상 별도 과제.

🤖 Generated with [Claude Code](https://claude.com/claude-code)