### PR TITLE
Serve thumbnails via direct CDN URLs to cut mobile LCP

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,8 @@ Metrics/ClassLength:
     - "test/**/*"
     - "db/**/*"
     - "spec/**/*"
+    # 대형 도메인 모델(연관/검색/federation/썸네일 등 다수 책임) — 길이 예외.
+    - "app/models/article.rb"
 
 Metrics/ModuleLength:
   Enabled: true

--- a/app/components/base.rb
+++ b/app/components/base.rb
@@ -8,6 +8,21 @@ class Components::Base < Phlex::HTML
 
   private
 
+  # 프로덕션(public R2 서비스)에서 처리된 변형의 .url 은 직접 CDN URL
+  # (cdn.ruby-news.dev)을 주므로 리다이렉트 왕복을 없앤다. 미처리라 .url 이
+  # 빈 문자열이거나, public URL을 만들 수 없는 서비스(dev/test의 Disk는
+  # url_options 필요)면 기본 리다이렉트 라우트로 폴백한다 — 요청 컨텍스트에서
+  # 항상 동작하고, 리다이렉트 컨트롤러가 지연 처리하므로 이미지가 깨지지 않는다.
+  def cdn_variant_url(attachment, variant_name)
+    variant = attachment.variant(variant_name)
+    direct = begin
+      variant.url
+    rescue StandardError
+      nil
+    end
+    direct.presence || helpers.url_for(variant)
+  end
+
   def safe_url(url)
     uri = URI.parse(url.to_s)
     %w[http https].include?(uri.scheme) ? url : nil

--- a/app/components/base.rb
+++ b/app/components/base.rb
@@ -9,19 +9,25 @@ class Components::Base < Phlex::HTML
 
   private
 
-  # 프로덕션(public R2 서비스)에서 처리된 변형의 .url 은 직접 CDN URL
-  # (cdn.ruby-news.dev)을 주므로 리다이렉트 왕복을 없앤다. 단 변형이 아직
-  # 처리되지 않았으면 .url 이 실제 파일이 없는 직접 URL을 반환해 브라우저가
-  # 404를 받으므로, 먼저 processed(public, 멱등)로 처리를 보장한 뒤 직접 URL을
-  # 얻는다 — 잡이 미리 처리해 뒀다면 no-op이고, 아니면 지연 처리라도 404는 없다.
+  # 처리된 변형의 .url 은 public R2 서비스에서 직접 CDN URL을 주므로 리다이렉트
+  # 왕복을 없앤다. 단 변형이 아직 처리되지 않았으면 .url 이 실제 파일이 없는 URL을
+  # 반환해 브라우저가 404를 받으므로, 먼저 processed 로 존재를 보장한다 —
+  # track_variants=true 라 이는 변형 레코드 DB 조회이고(R2 HEAD 아님), 잡이 미리
+  # 처리해 뒀다면 조회만, 아니면 동기 변환+업로드 후 직접 URL을 얻는다.
   # public URL을 만들 수 없는 서비스(dev/test의 Disk는 url_options 필요)면 기본
-  # 리다이렉트 라우트로 폴백한다 — 요청 컨텍스트에서 항상 동작하고, 리다이렉트
-  # 컨트롤러가 지연 처리하므로 이미지가 깨지지 않는다.
+  # 리다이렉트 라우트로 폴백한다 — 요청 컨텍스트에서 항상 동작하고 지연 처리된다.
   def cdn_variant_url(attachment, variant_name)
     variant = attachment.variant(variant_name)
     direct = begin
       variant.processed.url
-    rescue StandardError
+    rescue StandardError => e
+      # dev/test의 Disk 서비스는 url_options 미설정으로 예상된 실패라 조용히
+      # 폴백한다. 그 외(프로덕션의 R2 인증 실패·변형 오류 등)는 사이트 전역 LCP
+      # 회귀 신호이므로 삼키지 않고 로깅한다("no silent failures").
+      unless Rails.env.local?
+        Rails.logger.error("cdn_variant_url failed (#{variant_name}): #{e.class} - #{e.message}")
+        Sentry.capture_exception(e) if defined?(Sentry)
+      end
       nil
     end
     direct.presence || helpers.url_for(variant)

--- a/app/components/base.rb
+++ b/app/components/base.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rbs_inline: enabled
 
 class Components::Base < Phlex::HTML
   include RubyUI
@@ -9,14 +10,17 @@ class Components::Base < Phlex::HTML
   private
 
   # 프로덕션(public R2 서비스)에서 처리된 변형의 .url 은 직접 CDN URL
-  # (cdn.ruby-news.dev)을 주므로 리다이렉트 왕복을 없앤다. 미처리라 .url 이
-  # 빈 문자열이거나, public URL을 만들 수 없는 서비스(dev/test의 Disk는
-  # url_options 필요)면 기본 리다이렉트 라우트로 폴백한다 — 요청 컨텍스트에서
-  # 항상 동작하고, 리다이렉트 컨트롤러가 지연 처리하므로 이미지가 깨지지 않는다.
+  # (cdn.ruby-news.dev)을 주므로 리다이렉트 왕복을 없앤다. 단 변형이 아직
+  # 처리되지 않았으면 .url 이 실제 파일이 없는 직접 URL을 반환해 브라우저가
+  # 404를 받으므로, 먼저 processed(public, 멱등)로 처리를 보장한 뒤 직접 URL을
+  # 얻는다 — 잡이 미리 처리해 뒀다면 no-op이고, 아니면 지연 처리라도 404는 없다.
+  # public URL을 만들 수 없는 서비스(dev/test의 Disk는 url_options 필요)면 기본
+  # 리다이렉트 라우트로 폴백한다 — 요청 컨텍스트에서 항상 동작하고, 리다이렉트
+  # 컨트롤러가 지연 처리하므로 이미지가 깨지지 않는다.
   def cdn_variant_url(attachment, variant_name)
     variant = attachment.variant(variant_name)
     direct = begin
-      variant.url
+      variant.processed.url
     rescue StandardError
       nil
     end

--- a/app/components/home/feature.rb
+++ b/app/components/home/feature.rb
@@ -41,7 +41,7 @@ class Components::Home::Feature < Components::Base
       id: dom_id(article, :feature),
       class: "relative bg-surface border-border-muted hover:border-border-strong hover:shadow-md transition-all duration-300 overflow-hidden flex flex-col h-full"
     ) do
-      thumbnail(article, size: [ 1200, 675 ], aspect: "aspect-video", eager: true)
+      thumbnail(article, variant: :hero, aspect: "aspect-video", eager: true, responsive: true)
       div(class: "p-6 flex flex-col flex-1") do
         title_block(article, size: :large)
         render RubyUI::Badge.new(variant: :blue, size: :sm, class: "mb-4 self-start") { article.host }
@@ -56,7 +56,7 @@ class Components::Home::Feature < Components::Base
       id: dom_id(article, :feature),
       class: "relative bg-surface border-border-muted hover:border-border-strong hover:shadow-sm transition-all duration-300 overflow-hidden flex flex-col h-full"
     ) do
-      thumbnail(article, size: [ 600, 338 ], aspect: "aspect-video")
+      thumbnail(article, variant: :card, aspect: "aspect-video")
       div(class: "p-4 flex flex-col flex-1") do
         title_block(article, size: :small)
         render RubyUI::Badge.new(variant: :blue, size: :sm, class: "mb-3 self-start") { article.host }
@@ -65,18 +65,24 @@ class Components::Home::Feature < Components::Base
     end
   end
 
-  def thumbnail(article, size:, aspect:, eager: false)
+  def thumbnail(article, variant:, aspect:, eager: false, responsive: false)
     return unless article.thumbnail.attached?
 
+    attrs = {
+      class: "w-full #{aspect} object-cover",
+      loading: eager ? "eager" : "lazy",
+      decoding: eager ? "auto" : "async",
+      fetchpriority: eager ? "high" : "auto",
+      alt: article.display_title
+    }
+    # 히어로는 반응형 srcset으로 모바일에 작은 변형(600px)을 제공해 LCP 바이트를 줄인다.
+    if responsive
+      attrs[:srcset] = "#{cdn_variant_url(article.thumbnail, :card)} 600w, #{cdn_variant_url(article.thumbnail, :hero)} 1200w"
+      attrs[:sizes] = "(min-width: 1024px) 66vw, 100vw"
+    end
+
     link_to(article_path(article), class: "block overflow-hidden relative z-10") do
-      image_tag(
-        article.thumbnail.variant(resize_to_fill: size),
-        class: "w-full #{aspect} object-cover",
-        loading: eager ? "eager" : "lazy",
-        decoding: eager ? "auto" : "async",
-        fetchpriority: eager ? "high" : "auto",
-        alt: article.display_title
-      )
+      image_tag(cdn_variant_url(article.thumbnail, variant), **attrs)
     end
   end
 

--- a/app/components/home/feature.rb
+++ b/app/components/home/feature.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rbs_inline: enabled
 
 class Components::Home::Feature < Components::Base
   include Phlex::Rails::Helpers::DOMID
@@ -68,6 +69,8 @@ class Components::Home::Feature < Components::Base
   def thumbnail(article, variant:, aspect:, eager: false, responsive: false)
     return unless article.thumbnail.attached?
 
+    thumbnail_url = cdn_variant_url(article.thumbnail, variant)
+
     attrs = {
       class: "w-full #{aspect} object-cover",
       loading: eager ? "eager" : "lazy",
@@ -77,12 +80,14 @@ class Components::Home::Feature < Components::Base
     }
     # 히어로는 반응형 srcset으로 모바일에 작은 변형(600px)을 제공해 LCP 바이트를 줄인다.
     if responsive
-      attrs[:srcset] = "#{cdn_variant_url(article.thumbnail, :card)} 600w, #{cdn_variant_url(article.thumbnail, :hero)} 1200w"
+      card_url = (variant == :card) ? thumbnail_url : cdn_variant_url(article.thumbnail, :card)
+      hero_url = (variant == :hero) ? thumbnail_url : cdn_variant_url(article.thumbnail, :hero)
+      attrs[:srcset] = "#{card_url} 600w, #{hero_url} 1200w"
       attrs[:sizes] = "(min-width: 1024px) 66vw, 100vw"
     end
 
     link_to(article_path(article), class: "block overflow-hidden relative z-10") do
-      image_tag(cdn_variant_url(article.thumbnail, variant), **attrs)
+      image_tag(thumbnail_url, **attrs)
     end
   end
 

--- a/app/components/layout.rb
+++ b/app/components/layout.rb
@@ -170,6 +170,11 @@ class Components::Layout < Components::Base
   # 재사용한다. ruby-news.jp(same-origin)나 개발환경(asset_host nil)에서는 아무것도
   # 렌더하지 않는다.
   def render_asset_preconnect
+    # 이미지 CDN(cdn.ruby-news.dev): LCP 히어로 썸네일이 여기서 직접 서빙되므로
+    # 가장 먼저 연결을 예열한다(<img>는 비-CORS라 crossorigin 없이).
+    image_cdn = ENV["ACTIVE_STORAGE_CDN_HOST"].presence
+    link(rel: "preconnect", href: image_cdn.delete_suffix("/")) if image_cdn
+
     origin = asset_preconnect_origin
     return if origin.blank?
 

--- a/app/jobs/article_thumbnail_job.rb
+++ b/app/jobs/article_thumbnail_job.rb
@@ -34,15 +34,15 @@ class ArticleThumbnailJob < ApplicationJob
     end
 
     process_thumbnail_variants(article) if article.thumbnail.attached?
-  rescue ActiveRecord::RecordNotFound
-    logger.info "ArticleThumbnailJob skip: article #{article_id} not found"
   end
 
   private
 
   # 렌더 시 직접 CDN URL을 쓰려면 변형이 미리 처리돼 있어야 한다(미처리면 리다이렉트 폴백).
   # 이미 async 잡이므로 여기서 동기 처리해 첫 페이지 렌더의 지연/리다이렉트를 없앤다.
-  # 에러를 잡지 않고 전파시켜 ActiveJob 재시도가 변형 처리를 다시 시도하게 한다.
+  # 에러는 잡지 않고 전파시킨다 — 변형 에러(Vips/S3 등)는 ApplicationJob의 retry_on
+  # 대상이 아니라 잡이 실패로 남고(rescue_from이 로깅 후 re-raise), MissionControl에서
+  # 수동 재시도하면 위 already-attached 분기가 썸네일 재생성 없이 변형만 다시 처리한다.
   #: (Article article) -> void
   def process_thumbnail_variants(article)
     Article::THUMBNAIL_VARIANTS.each_key do |name|

--- a/app/jobs/article_thumbnail_job.rb
+++ b/app/jobs/article_thumbnail_job.rb
@@ -19,6 +19,9 @@ class ArticleThumbnailJob < ApplicationJob
         article.thumbnail.purge
         logger.info "ArticleThumbnailJob purged existing thumbnail for article #{article_id} (force)"
       else
+        # 썸네일은 이미 있지만 변형이 아직 처리 안 됐을 수 있다(이전 잡이 변형 처리
+        # 단계에서 실패해 재시도된 경우 등). 생성은 건너뛰되 변형 처리를 다시 시도한다.
+        process_thumbnail_variants(article)
         logger.info "ArticleThumbnailJob skip: article #{article_id} already has thumbnail"
         return
       end
@@ -39,14 +42,13 @@ class ArticleThumbnailJob < ApplicationJob
 
   # 렌더 시 직접 CDN URL을 쓰려면 변형이 미리 처리돼 있어야 한다(미처리면 리다이렉트 폴백).
   # 이미 async 잡이므로 여기서 동기 처리해 첫 페이지 렌더의 지연/리다이렉트를 없앤다.
+  # 에러를 잡지 않고 전파시켜 ActiveJob 재시도가 변형 처리를 다시 시도하게 한다.
   #: (Article article) -> void
   def process_thumbnail_variants(article)
     Article::THUMBNAIL_VARIANTS.each_key do |name|
       article.thumbnail.variant(name).processed
     end
     logger.info "ArticleThumbnailJob processed thumbnail variants for article #{article.id}"
-  rescue StandardError => e
-    logger.warn "ArticleThumbnailJob variant processing failed for article #{article.id}: #{e.class} - #{e.message}"
   end
 
   # YouTube 썸네일 해상도 후보 (높은 순)

--- a/app/jobs/article_thumbnail_job.rb
+++ b/app/jobs/article_thumbnail_job.rb
@@ -29,11 +29,25 @@ class ArticleThumbnailJob < ApplicationJob
     else
       generate_ai_thumbnail(article)
     end
+
+    process_thumbnail_variants(article) if article.thumbnail.attached?
   rescue ActiveRecord::RecordNotFound
     logger.info "ArticleThumbnailJob skip: article #{article_id} not found"
   end
 
   private
+
+  # 렌더 시 직접 CDN URL을 쓰려면 변형이 미리 처리돼 있어야 한다(미처리면 리다이렉트 폴백).
+  # 이미 async 잡이므로 여기서 동기 처리해 첫 페이지 렌더의 지연/리다이렉트를 없앤다.
+  #: (Article article) -> void
+  def process_thumbnail_variants(article)
+    Article::THUMBNAIL_VARIANTS.each_key do |name|
+      article.thumbnail.variant(name).processed
+    end
+    logger.info "ArticleThumbnailJob processed thumbnail variants for article #{article.id}"
+  rescue StandardError => e
+    logger.warn "ArticleThumbnailJob variant processing failed for article #{article.id}: #{e.class} - #{e.message}"
+  end
 
   # YouTube 썸네일 해상도 후보 (높은 순)
   YOUTUBE_THUMBNAIL_QUALITIES = %w[maxresdefault sddefault hqdefault mqdefault default].freeze

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -54,7 +54,16 @@ class Article < ApplicationRecord
   has_many :posts, dependent: :nullify
   has_many :notification_deliveries, dependent: :destroy
 
-  has_one_attached :thumbnail
+  # 명명된 변형: 렌더 시 직접 CDN URL(cdn.ruby-news.dev)을 쓰기 위해 미리 처리해 둔다.
+  # (기존 인라인 변형과 동일한 resize_to_fill 이라 digest/key가 같아 재사용된다.)
+  #   :hero → 히어로/기사 상세, :card → 작은 카드 및 히어로 모바일 srcset
+  THUMBNAIL_VARIANTS = { hero: [ 1200, 675 ], card: [ 600, 338 ] }.freeze
+
+  has_one_attached :thumbnail do |attachable|
+    THUMBNAIL_VARIANTS.each do |name, dimensions|
+      attachable.variant name, resize_to_fill: dimensions
+    end
+  end
 
   # ── Scopes ───────────────────────────────────────────────────────────
   # 하이브리드 전문 검색:

--- a/app/views/articles/show.rb
+++ b/app/views/articles/show.rb
@@ -55,8 +55,10 @@ class Views::Articles::Show < Views::Base
 
     div(class: "w-full overflow-hidden") do
       image_tag(
-        @article.thumbnail.variant(resize_to_fill: [ 1200, 675 ]),
+        cdn_variant_url(@article.thumbnail, :hero),
         class: "w-full aspect-video object-cover",
+        srcset: "#{cdn_variant_url(@article.thumbnail, :card)} 600w, #{cdn_variant_url(@article.thumbnail, :hero)} 1200w",
+        sizes: "(min-width: 768px) 768px, 100vw",
         loading: "eager",
         decoding: "auto",
         fetchpriority: "high",

--- a/lib/tasks/thumbnail_variants.rake
+++ b/lib/tasks/thumbnail_variants.rake
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rbs_inline: enabled
 
 namespace :thumbnails do
   desc "기존 기사 썸네일의 명명 변형(hero/card)을 미리 생성해 렌더 시 직접 CDN URL을 쓰게 한다. " \
@@ -25,7 +26,7 @@ namespace :thumbnails do
 
     processed = 0
     failed = 0
-    scope.find_each(batch_size: batch_size) do |article|
+    scope.with_attached_thumbnail.find_each(batch_size: batch_size) do |article|
       variant_names.each do |name|
         article.thumbnail.variant(name).processed
       end

--- a/lib/tasks/thumbnail_variants.rake
+++ b/lib/tasks/thumbnail_variants.rake
@@ -32,6 +32,9 @@ namespace :thumbnails do
       end
       processed += 1
       puts "  진행: #{processed}/#{total}" if (processed % batch_size).zero?
+    rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::StatementInvalid
+      # 시스템 장애(DB 연결 끊김 등)는 건별 실패로 세지 말고 즉시 중단한다.
+      raise
     rescue StandardError => e
       failed += 1
       warn "  실패 article=#{article.id}: #{e.class} - #{e.message}"

--- a/lib/tasks/thumbnail_variants.rake
+++ b/lib/tasks/thumbnail_variants.rake
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+namespace :thumbnails do
+  desc "기존 기사 썸네일의 명명 변형(hero/card)을 미리 생성해 렌더 시 직접 CDN URL을 쓰게 한다. " \
+       "옵션: DRY_RUN=true BATCH_SIZE=100"
+  task backfill_variants: :environment do
+    boolean = ActiveModel::Type::Boolean.new
+    dry_run = boolean.cast(ENV["DRY_RUN"])
+    batch_size = (ENV["BATCH_SIZE"].presence || 100).to_i
+    variant_names = Article::THUMBNAIL_VARIANTS.keys
+
+    scope = Article.joins(:thumbnail_attachment)
+    total = scope.count
+    puts "썸네일 변형 백필 대상: #{total} articles × #{variant_names.size} variants (#{variant_names.join(', ')})"
+
+    if dry_run
+      puts "[DRY_RUN] 처리 생략"
+      next
+    end
+
+    if total.zero?
+      puts "대상 없음. 종료."
+      next
+    end
+
+    processed = 0
+    failed = 0
+    scope.find_each(batch_size: batch_size) do |article|
+      variant_names.each do |name|
+        article.thumbnail.variant(name).processed
+      end
+      processed += 1
+      puts "  진행: #{processed}/#{total}" if (processed % batch_size).zero?
+    rescue StandardError => e
+      failed += 1
+      warn "  실패 article=#{article.id}: #{e.class} - #{e.message}"
+    end
+
+    puts "완료: 처리 #{processed} / 실패 #{failed} / 전체 #{total}"
+  end
+end

--- a/sig/generated/components/base.rbs
+++ b/sig/generated/components/base.rbs
@@ -1,0 +1,26 @@
+# Generated from app/components/base.rb with RBS::Inline
+
+class Components::Base < Phlex::HTML
+  include RubyUI
+
+  include Phlex::Rails::Helpers::Routes
+
+  include Phlex::Rails::Helpers::T
+
+  private
+
+  # 처리된 변형의 .url 은 public R2 서비스에서 직접 CDN URL을 주므로 리다이렉트
+  # 왕복을 없앤다. 단 변형이 아직 처리되지 않았으면 .url 이 실제 파일이 없는 URL을
+  # 반환해 브라우저가 404를 받으므로, 먼저 processed 로 존재를 보장한다 —
+  # track_variants=true 라 이는 변형 레코드 DB 조회이고(R2 HEAD 아님), 잡이 미리
+  # 처리해 뒀다면 조회만, 아니면 동기 변환+업로드 후 직접 URL을 얻는다.
+  # public URL을 만들 수 없는 서비스(dev/test의 Disk는 url_options 필요)면 기본
+  # 리다이렉트 라우트로 폴백한다 — 요청 컨텍스트에서 항상 동작하고 지연 처리된다.
+  def cdn_variant_url: (untyped attachment, untyped variant_name) -> untyped
+
+  def safe_url: (untyped url) -> untyped
+
+  def post_permalink_path: (untyped post) -> untyped
+
+  def before_template: () -> untyped
+end

--- a/sig/generated/components/home/feature.rbs
+++ b/sig/generated/components/home/feature.rbs
@@ -1,0 +1,29 @@
+# Generated from app/components/home/feature.rb with RBS::Inline
+
+class Components::Home::Feature < Components::Base
+  include Phlex::Rails::Helpers::DOMID
+
+  include Phlex::Rails::Helpers::LinkTo
+
+  include Phlex::Rails::Helpers::ImageTag
+
+  include PhlexIcons
+
+  def initialize: (articles: untyped, ?liked_article_ids: untyped, ?boosted_article_ids: untyped) -> untyped
+
+  def view_template: () -> untyped
+
+  private
+
+  def hero_card: (untyped article) -> untyped
+
+  def small_card: (untyped article) -> untyped
+
+  def thumbnail: (untyped article, variant: untyped, aspect: untyped, ?eager: untyped, ?responsive: untyped) -> untyped
+
+  def title_block: (untyped article, size: untyped) -> untyped
+
+  def summary_block: (untyped article) -> untyped
+
+  def meta_block: (untyped article) -> untyped
+end

--- a/sig/generated/jobs/article_thumbnail_job.rbs
+++ b/sig/generated/jobs/article_thumbnail_job.rbs
@@ -7,6 +7,14 @@ class ArticleThumbnailJob < ApplicationJob
 
   private
 
+  # 렌더 시 직접 CDN URL을 쓰려면 변형이 미리 처리돼 있어야 한다(미처리면 리다이렉트 폴백).
+  # 이미 async 잡이므로 여기서 동기 처리해 첫 페이지 렌더의 지연/리다이렉트를 없앤다.
+  # 에러는 잡지 않고 전파시킨다 — 변형 에러(Vips/S3 등)는 ApplicationJob의 retry_on
+  # 대상이 아니라 잡이 실패로 남고(rescue_from이 로깅 후 re-raise), MissionControl에서
+  # 수동 재시도하면 위 already-attached 분기가 썸네일 재생성 없이 변형만 다시 처리한다.
+  # : (Article article) -> void
+  def process_thumbnail_variants: (Article article) -> void
+
   # YouTube 썸네일 해상도 후보 (높은 순)
   YOUTUBE_THUMBNAIL_QUALITIES: untyped
 

--- a/sig/generated/models/article.rbs
+++ b/sig/generated/models/article.rbs
@@ -31,6 +31,11 @@ class Article < ApplicationRecord
 
   include Articles::Activitypub
 
+  # 명명된 변형: 렌더 시 직접 CDN URL(cdn.ruby-news.dev)을 쓰기 위해 미리 처리해 둔다.
+  # (기존 인라인 변형과 동일한 resize_to_fill 이라 digest/key가 같아 재사용된다.)
+  #   :hero → 히어로/기사 상세, :card → 작은 카드 및 히어로 모바일 srcset
+  THUMBNAIL_VARIANTS: untyped
+
   # ── Scopes ───────────────────────────────────────────────────────────
   # 하이브리드 전문 검색:
   #   1) tsvector_content_tsearch(textsearch_ko, 'korean') — 한국어 형태소 + 한자

--- a/test/jobs/article_thumbnail_job_test.rb
+++ b/test/jobs/article_thumbnail_job_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ArticleThumbnailJobTest < ActiveSupport::TestCase
+  # 1x1 투명 PNG (변형 실제 처리는 스텁하므로 attached? 만 참이면 된다)
+  ONE_PX_PNG = Base64.decode64(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+  )
+
+  test "썸네일이 이미 있으면 재생성 없이 변형만 다시 처리한다" do
+    article = articles(:ruby_article)
+    article.thumbnail.attach(io: StringIO.new(ONE_PX_PNG), filename: "t.png", content_type: "image/png")
+
+    job = ArticleThumbnailJob.new
+    processed = false
+    job.stub(:process_thumbnail_variants, ->(_article) { processed = true }) do
+      job.stub(:generate_ai_thumbnail, ->(_article) { flunk "should not regenerate thumbnail" }) do
+        job.stub(:attach_youtube_thumbnail, ->(_article) { flunk "should not regenerate thumbnail" }) do
+          job.perform(article.id)
+        end
+      end
+    end
+
+    assert processed, "already-attached 분기에서 변형을 다시 처리해야 한다"
+  end
+
+  test "process_thumbnail_variants는 변형 처리 에러를 삼키지 않고 전파한다" do
+    article = articles(:ruby_article)
+
+    failing_variant = Object.new
+    failing_variant.define_singleton_method(:processed) { raise "boom" }
+    fake_attachment = Object.new
+    fake_attachment.define_singleton_method(:variant) { |_name| failing_variant }
+
+    job = ArticleThumbnailJob.new
+
+    article.stub(:thumbnail, fake_attachment) do
+      assert_raises(RuntimeError) { job.send(:process_thumbnail_variants, article) }
+    end
+  end
+end


### PR DESCRIPTION
## 배경

앞선 JS/CSS 최적화 후에도 **모바일 PageSpeed는 61**(데스크톱 ~90)에 머물렀습니다. 서버 TTFB(~165ms)와 JS는 이미 좋고, 병목은 **LCP 히어로 이미지**였습니다.

라이브 HTML 확인 결과 LCP 이미지가 ActiveStorage **리다이렉트**로 서빙되고 있었습니다:
```
src="https://ruby-news.dev/rails/active_storage/representations/redirect/…"  → 302 → https://cdn.ruby-news.dev/<key>
```
스로틀된 4G에서 이 **추가 왕복 1회**가 LCP를 크게 늘립니다. 공개 R2 CDN(`cdn.ruby-news.dev`)과 `public_url` 패치는 **이미 존재**했고, HTML이 직접 URL을 안 내보내는 게 문제였습니다(인프라 아님, 코드).

## 변경

- **명명 변형**(`:hero` 1200×675, `:card` 600×338)을 Article에 정의. 기존과 동일한 `resize_to_fill`이라 digest/key가 같아 **기존 처리된 변형을 재사용**(재생성 아님).
- **`cdn_variant_url` 헬퍼**: public 서비스에서 변형의 **직접 CDN URL**을 내보내고, 미처리이거나 public URL을 못 만드는 서비스(dev/test Disk)면 리다이렉트 라우트로 폴백 — 절대 깨지지 않고 자가 치유.
- **히어로 반응형 srcset**(모바일 600w / 데스크톱 1200w) → 모바일이 작은 변형을 받아 **LCP 바이트 대폭 절감**.
- **변형 사전 처리**: `ArticleThumbnailJob`에서 attach 후 처리 + 기존용 `thumbnails:backfill_variants` rake(첫 렌더가 동기 리사이즈/리다이렉트가 되지 않도록).
- **이미지 CDN preconnect**를 `<head>` 최우선에 추가(`ACTIVE_STORAGE_CDN_HOST`).
- 대형 `Article` 모델을 `Metrics/ClassLength` 예외로(정확히 200 한계였음).

## 검증

- **home·articles 컨트롤러 테스트(실제 요청)**, **blog_posts·boosts 시스템 테스트(실제 브라우저)** 통과.
- dev 콘솔: `variant(:hero).url → https://cdn.ruby-news.dev/…` 직접 URL(리다이렉트 없음) 확인. 미처리/Disk 폴백 경로도 확인.
- rubocop(model/job) 통과.

## 배포 후 조치 (필수)
1. **`rails thumbnails:backfill_variants`** 실행 — 기존 564개 기사 썸네일의 hero/card 변형 사전 생성.
2. 배포 후 홈 HTML의 히어로 `<img src>`가 `cdn.ruby-news.dev` 직접 URL이고 `/representations/redirect/`가 없는지 확인.
3. 모바일 Lighthouse/CrUX before-after 측정으로 LCP 개선 확인.

## 참고 / 한계
- 프로덕션(R2 public)에서만 직접 CDN URL. test(Disk)는 리다이렉트 폴백(정상 — test엔 CDN 없음).
- `.url`이 변형 레코드 조회를 하므로 피드 이미지당 DB 조회 1회 추가(가벼운 인덱스 조회). 필요 시 후속으로 프리로드 최적화 가능.
- User 아바타는 LCP 아니라 이번 범위 제외(여전히 리다이렉트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 기사 썸네일이 hero/card 변형과 반응형 소스셋(srcset/sizes) 기반으로 제공되어, 화면별로 더 선명하고 빠르게 표시됩니다.
  * 이미지 CDN 호스트에 대한 사전 연결(preconnect)을 추가해 로딩 성능을 개선했습니다.
* **버그 수정**
  * 썸네일 변형 사전 생성/일괄 백필과 잡 처리 보강으로, 변형 누락 시에도 대체 경로로 표시되어 이미지 깨짐을 줄였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->