### PR TITLE
R2 업로드 오브젝트에 Cache-Control 헤더 설정

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -39,6 +39,13 @@ cloudflare:
   request_checksum_calculation: when_required
   response_checksum_validation: when_required
   public: true
+  # 업로드하는 R2 오브젝트에 Cache-Control을 직접 심는다. 썸네일 변형 키는
+  # fingerprint(불변)라 브라우저/엣지가 오래 캐시해도 안전하다. Cloudflare Cache
+  # Rule이 엣지 TTL을 이미 오버라이드하지만, 오브젝트 헤더로 브라우저 캐시와
+  # 오리진 응답까지 일관되게 만든다. ActiveStorage S3 서비스는 upload 옵션을
+  # put_object에 그대로 전달한다(신규 업로드에만 적용, 기존 오브젝트는 백필 필요).
+  upload:
+    cache_control: "public, max-age=31536000, immutable"
 
 # mirror:
 #   service: Mirror


### PR DESCRIPTION
## 배경
모바일 Lighthouse `cache-insight`가 cdn.ruby-news.dev 이미지의 `cacheLifetimeMs: 0`(Cache-Control 없음)을 LCP 최대 레버(−900ms)로 지목. Cloudflare Cache Rule이 엣지 TTL을 이미 오버라이드하지만, 오브젝트 자체에 헤더를 심어 브라우저 캐시와 오리진 응답까지 일관되게 만든다.

## 변경
`config/storage.yml`의 cloudflare(R2/S3) 서비스에 `upload.cache_control` 추가:
```yaml
upload:
  cache_control: "public, max-age=31536000, immutable"
```
ActiveStorage `S3Service`는 `upload:` 옵션을 `object.put(..., **upload_options)`로 그대로 전달하므로, 업로드 시 put_object에 `Cache-Control` 헤더가 실린다. 썸네일 변형 키는 fingerprint(불변)라 1년 immutable이 안전하다.

## 검증
- Rails 컨텍스트에서 `config/storage.yml` 파싱 확인 → `cloudflare.upload => {"cache_control" => "public, max-age=31536000, immutable"}`.
- activestorage-8.1.3 `S3Service#upload_with_single_part`가 `**upload_options`를 put에 전달함을 확인(썸네일 <5MB → single-part).

## 범위/한계
- **신규 업로드에만 적용.** 기존 R2 오브젝트는 헤더가 없다 → 필요 시 copy-object로 메타데이터를 재설정하는 백필이 별도로 필요. 다만 Cloudflare Cache Rule이 엣지 TTL을 이미 커버하므로 기존 오브젝트도 엣지 캐싱은 동작한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)