### PR TITLE
[Audit][TEST-01] .jp noindex 스펙을 summary_key_ja 신호에 맞게 갱신 (#836)

### DIFF
--- a/spec/requests/articles_show_noindex_spec.rb
+++ b/spec/requests/articles_show_noindex_spec.rb
@@ -19,8 +19,10 @@ RSpec.describe "Articles show noindex / hreflang by translation availability", t
     body.scan(%r{<link rel="alternate" hreflang="([^"]+)" href}).flatten
   end
 
-  context "일본어 번역이 없는 기사 (title_ja 없음)" do
-    before { article.update!(title_ja: nil) }
+  context "일본어 번역이 없는 기사 (summary_key_ja 없음)" do
+    # 번역 완료 신호는 summary_key_ja(번역 파이프라인이 세팅). title_ja는
+    # 일본어 원문 제목으로 미리 채워질 수 있어 신호로 쓰지 않는다(#809).
+    before { article.update!(title_ja: nil, summary_key_ja: nil) }
 
     it ".jp 호스트에서 noindex 이고 ja hreflang alternate 가 없다" do
       host! "ruby-news.jp"
@@ -43,8 +45,8 @@ RSpec.describe "Articles show noindex / hreflang by translation availability", t
     end
   end
 
-  context "일본어 번역이 있는 기사 (title_ja 존재)" do
-    before { article.update!(title_ja: "Ruby 3.4 の新機能") }
+  context "일본어 번역이 있는 기사 (summary_key_ja 존재)" do
+    before { article.update!(title_ja: "Ruby 3.4 の新機能", summary_key_ja: [ "Ruby 3.4 の主な改善点" ]) }
 
     it ".jp 호스트에서 색인 가능하고 ja/ko hreflang 을 모두 광고한다" do
       host! "ruby-news.jp"


### PR DESCRIPTION
## 배경
`spec/requests/articles_show_noindex_spec.rb`의 실패 테스트 1건으로 RSpec 스위트가 red 상태였습니다 (Audit TEST-01, #836).

## 원인
#809에서 일본어 번역 완료 신호를 `title_ja` → `summary_key_ja`로 **의도적으로 변경**했습니다. `title_ja`는 일본어 원문 제목으로 미리 채워질 수 있어 "번역 완료" 신호로 부적합하고, 실제 번역 파이프라인(`run_japanese`/DeepL)이 세팅하는 `summary_key_ja`가 진짜 신호이기 때문입니다.

그러나 이 request 스펙은 갱신되지 않아 `title_ja`만 설정하고 색인 가능을 기대 → `available_in?(:ja)`가 `false`(noindex)를 반환하며 실패했습니다. **프로덕션 로직이 정답**이고 테스트가 stale이었습니다.

## 변경
- "번역 있음" 컨텍스트: `summary_key_ja`를 함께 설정
- "번역 없음" 컨텍스트: `summary_key_ja: nil` 명시 + 신호 기준을 주석으로 문서화

## 검증
- `spec/requests/articles_show_noindex_spec.rb` — 3 examples, 0 failures
- `test/models/concerns/localized_display_test.rb`, `test/jobs/japanese_temp_job_test.rb` — 23 runs, 0 failures

Closes #836

🤖 Generated with [Claude Code](https://claude.com/claude-code)