### PR TITLE
lexxy 컴포저 에디터 시간차 렌더링 제거 (업그레이드 전 높이 예약)

### DIFF
--- a/app/assets/tailwind/site.css
+++ b/app/assets/tailwind/site.css
@@ -45,6 +45,12 @@ lexxy-editor.post-composer-editor {
     --lexxy-radius: 0.75rem;
 
     @apply overflow-hidden rounded-lg border border-border-muted bg-surface text-content shadow-none transition-colors duration-200;
+
+    /* <lexxy-editor>는 커스텀 엘리먼트라 JS가 실행되기 전에는 내부 content div가
+       없어 0 높이로 접힌다. 마운트되면 .lexxy-editor__content가 5줄(5 × leading-6)로
+       펼쳐지므로, 마운트 전에도 같은 높이를 예약해 "시간차로 그려짐"(얇은 선 → 5줄
+       점프)을 없앤다. 값이 content의 min-block-size와 일치해 마운트 후에도 시프트 없음. */
+    min-block-size: calc(5 * 1.5rem);
 }
 
 lexxy-editor.post-composer-editor:focus-within {

--- a/app/assets/tailwind/site.css
+++ b/app/assets/tailwind/site.css
@@ -45,11 +45,15 @@ lexxy-editor.post-composer-editor {
     --lexxy-radius: 0.75rem;
 
     @apply overflow-hidden rounded-lg border border-border-muted bg-surface text-content shadow-none transition-colors duration-200;
+}
 
-    /* <lexxy-editor>는 커스텀 엘리먼트라 JS가 실행되기 전에는 내부 content div가
-       없어 0 높이로 접힌다. 마운트되면 .lexxy-editor__content가 5줄(5 × leading-6)로
-       펼쳐지므로, 마운트 전에도 같은 높이를 예약해 "시간차로 그려짐"(얇은 선 → 5줄
-       점프)을 없앤다. 값이 content의 min-block-size와 일치해 마운트 후에도 시프트 없음. */
+/* <lexxy-editor>는 커스텀 엘리먼트라 JS가 실행되기 전에는 내부 content div가
+   없어 0 높이로 접힌다. 마운트되면 .lexxy-editor__content가 5줄(5 × leading-6)로
+   펼쳐지므로, 마운트 전에도 같은 높이를 예약해 "시간차로 그려짐"(얇은 선 → 5줄
+   점프)을 없앤다. 값이 content의 min-block-size와 일치해 마운트 후에도 시프트 없음.
+   단독 클래스(명시도 0-1-0)로 정의해 BlogEditor의 min-h-[520px] 유틸리티가
+   동일 명시도에서 소스 순서로 덮어쓸 수 있게 한다. */
+.post-composer-editor {
     min-block-size: calc(5 * 1.5rem);
 }
 

--- a/test/components/lexxy_loading_test.rb
+++ b/test/components/lexxy_loading_test.rb
@@ -36,7 +36,7 @@ class LexxyLoadingTest < ActiveSupport::TestCase
   # 없앤다. 예약이 빠지면 얇은 선 → 5줄 점프 회귀가 되돌아온다.
   test "컴포저 lexxy 에디터는 업그레이드 전 높이를 예약해 레이아웃 시프트를 막는다" do
     assert_match(
-      /lexxy-editor\.post-composer-editor\b[^}]*min-block-size:/m,
+      /\.post-composer-editor\b[^}]*min-block-size:/m,
       SITE_CSS,
       "post-composer-editor에 min-block-size 높이 예약이 있어야 한다"
     )

--- a/test/components/lexxy_loading_test.rb
+++ b/test/components/lexxy_loading_test.rb
@@ -9,6 +9,7 @@ class LexxyLoadingTest < ActiveSupport::TestCase
   APPLICATION_JS = Rails.root.join("app/javascript/application.js").read
   IMPORTMAP = Rails.root.join("config/importmap.rb").read
   LAYOUT = Rails.root.join("app/components/layout.rb").read
+  SITE_CSS = Rails.root.join("app/assets/tailwind/site.css").read
 
   test "application.js는 lexxy를 최상위에서 eager import한다(동적 import 아님)" do
     assert_match(/^import "lexxy";$/, APPLICATION_JS)
@@ -27,5 +28,17 @@ class LexxyLoadingTest < ActiveSupport::TestCase
 
   test "Components::Base는 lexxy_editor_asset_tags를 정의하지 않는다" do
     refute Components::Base.private_method_defined?(:lexxy_editor_asset_tags)
+  end
+
+  # 커스텀 엘리먼트 업그레이드 전(JS 실행 전) <lexxy-editor>는 내부 content div가
+  # 없어 0 높이로 접혔다가, JS 마운트 후 5줄 높이로 펼쳐진다("시간차로 그려짐").
+  # 컴포저 에디터 자체에 마운트 후 높이와 같은 min-block-size를 예약해 이 시프트를
+  # 없앤다. 예약이 빠지면 얇은 선 → 5줄 점프 회귀가 되돌아온다.
+  test "컴포저 lexxy 에디터는 업그레이드 전 높이를 예약해 레이아웃 시프트를 막는다" do
+    assert_match(
+      /lexxy-editor\.post-composer-editor\b[^}]*min-block-size:/m,
+      SITE_CSS,
+      "post-composer-editor에 min-block-size 높이 예약이 있어야 한다"
+    )
   end
 end


### PR DESCRIPTION
## 배경

`<lexxy-editor>` 커스텀 에디터가 페이지 로드 시 **시간차로 그려지는** 문제. eager 로딩 원복(#이전 작업)으로도 지연이 남아 있었다.

## 근본 원인

로딩 레이어가 아니라 **커스텀 엘리먼트 업그레이드 시 높이 미예약**이 원인.

- `<lexxy-editor>`는 커스텀 엘리먼트라 lexxy JS 실행 전에는 내부 `.lexxy-editor__content` div가 없어 **0 높이로 접힘** (컴포즈 카드 상단 얇은 선).
- JS 실행 → `connectedCallback` → `requestAnimationFrame`으로 content 마운트되며 **5줄 높이로 펼쳐짐** → 이 점프가 "시간차".
- gem CSS의 `min-block-size: var(--lexxy-editor-rows)`는 JS가 만든 content div에만 걸려 마운트 전에는 무효.
- `BlogEditor`는 `min-h-[520px]`로 엘리먼트 높이를 예약해 지연 없음. 반면 `post-composer-editor`(피드 컴포저·댓글·답글 폼 3곳 공유)는 예약이 없었음.

## 변경

- `app/assets/tailwind/site.css`: `lexxy-editor.post-composer-editor`에 마운트 후 높이와 동일한 `min-block-size: calc(5 * 1.5rem)`(= 7.5rem, 5줄 × leading-6) 예약. 마운트 전/후 높이가 같아져 레이아웃 시프트 제거. 세 컴포저가 같은 클래스를 공유하므로 한 곳 수정으로 전부 해결.
- `test/components/lexxy_loading_test.rb`: 예약이 빠지면 회귀하므로 방지 테스트 추가.

## 검증

- `bin/rails tailwindcss:build` — 빌드 산출물에 `min-block-size:7.5rem` 반영 확인
- `bin/rails test test/components/lexxy_loading_test.rb` — 5 runs, 0 failures

## 확인 요청

피드 페이지 새로고침 시 컴포저가 얇은 선 없이 처음부터 제 높이로 뜨는지 확인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 에디터가 로드되는 동안 높이가 0으로 축소되었다가 확장되는 레이아웃 시프트를 방지했습니다.
  * 에디터 콘텐츠 영역에 최소 높이를 적용해 보다 안정적인 화면 표시를 제공합니다.

* **테스트**
  * 에디터 스타일에 최소 높이 설정이 포함되는지 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->