### PR TITLE
[Audit][SEC-01~02] 세션 축소 및 raw 렌더 심층방어 (#841)

### DIFF
--- a/app/components/comments/comment.rb
+++ b/app/components/comments/comment.rb
@@ -85,7 +85,7 @@ class Components::Comments::Comment < Components::Base
 
   def comment_body
     div(class: "text-content-secondary leading-relaxed prose prose-sm dark:prose-invert max-w-none") do
-      raw sanitize(@comment.body, tags: HtmlSanitizable::ALLOWED_TAGS)
+      raw sanitize(@comment.body.to_s, tags: HtmlSanitizable::ALLOWED_TAGS)
     end
   end
 

--- a/app/components/comments/comment.rb
+++ b/app/components/comments/comment.rb
@@ -4,6 +4,7 @@ class Components::Comments::Comment < Components::Base
   include Phlex::Rails::Helpers::ButtonTo
   include PhlexIcons
   include Phlex::Rails::Helpers::DOMID
+  include Phlex::Rails::Helpers::Sanitize
 
   def initialize(comment:, article:, depth: 0, children: {})
     @comment = comment
@@ -84,7 +85,7 @@ class Components::Comments::Comment < Components::Base
 
   def comment_body
     div(class: "text-content-secondary leading-relaxed prose prose-sm dark:prose-invert max-w-none") do
-      raw @comment.body.html_safe
+      raw sanitize(@comment.body, tags: HtmlSanitizable::ALLOWED_TAGS)
     end
   end
 

--- a/app/components/posts/post_card.rb
+++ b/app/components/posts/post_card.rb
@@ -3,6 +3,7 @@
 class Components::Posts::PostCard < Components::Base
   include Phlex::Rails::Helpers::DOMID
   include Phlex::Rails::Helpers::LinkTo
+  include Phlex::Rails::Helpers::Sanitize
   include PhlexIcons
 
   def initialize(post:, depth: 0, liked: nil, boosted: nil, booster: nil, show_actions: true, show_reply_badge: true)
@@ -108,7 +109,7 @@ class Components::Posts::PostCard < Components::Base
 
   def short_body
     div(class: "post-content text-content leading-relaxed wrap-break-word prose prose-sm dark:prose-invert max-w-none") do
-      raw @post.body.html_safe
+      raw sanitize(@post.body, tags: HtmlSanitizable::ALLOWED_TAGS)
     end
   end
 

--- a/app/components/posts/post_card.rb
+++ b/app/components/posts/post_card.rb
@@ -109,7 +109,7 @@ class Components::Posts::PostCard < Components::Base
 
   def short_body
     div(class: "post-content text-content leading-relaxed wrap-break-word prose prose-sm dark:prose-invert max-w-none") do
-      raw sanitize(@post.body, tags: HtmlSanitizable::ALLOWED_TAGS)
+      raw sanitize(@post.body.to_s, tags: HtmlSanitizable::ALLOWED_TAGS)
     end
   end
 

--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -18,24 +18,25 @@ class BlogPostsController < ApplicationController
   # first autosave (or publish) persists it via #create.
   #
   # The composer POSTs the in-progress body here so it stays out of the URL; we
-  # stash it in the session and redirect to the GET editor (Turbo follows the
-  # redirect and renders the page). Opening the editor directly (GET) carries
-  # over that stashed body once, then starts fresh.
+  # stash it in the cache under a per-request nonce and redirect to the GET
+  # editor (Turbo follows the redirect and renders the page). Opening the editor
+  # directly (GET) carries over that stashed body once, then starts fresh. The
+  # nonce travels in the redirect URL query, so no session state is needed.
   def new
     if request.post?
       draft_key = SecureRandom.hex(8)
-      session[:blog_draft_bodies] ||= {}
-      session[:blog_draft_bodies][draft_key] = params.dig(:post, :body).to_s
+      # User-scoped key so one user can't read another's stashed body, plus a
+      # TTL so abandoned drafts don't linger. The nonce keeps concurrent tabs
+      # from clobbering each other.
+      Rails.cache.write(blog_draft_cache_key(draft_key), params.dig(:post, :body).to_s, expires_in: 1.day)
       return redirect_to new_blog_post_path(draft_key: draft_key), status: :see_other
     end
 
-    draft_bodies = session[:blog_draft_bodies] || {}
     @post = current_user.posts.new(
       post_type: :blog,
       status: :draft,
-      body: draft_bodies.delete(params[:draft_key]).to_s
+      body: carried_over_draft_body
     )
-    session[:blog_draft_bodies] = draft_bodies
     render Views::BlogPosts::Edit.new(post: @post)
   end
 
@@ -115,6 +116,25 @@ class BlogPostsController < ApplicationController
   end
 
   private
+
+  # Reads and consumes (one-shot) the body stashed by the composer's POST. A
+  # missing nonce or cache miss (expired/consumed) yields a blank body so the
+  # editor starts fresh.
+  def carried_over_draft_body
+    draft_key = params[:draft_key]
+    return "" if draft_key.blank?
+
+    key = blog_draft_cache_key(draft_key)
+    body = Rails.cache.read(key)
+    Rails.cache.delete(key)
+    body.to_s
+  end
+
+  # Namespaced under the current user so a stashed body is only ever readable by
+  # the account that wrote it (defense in depth against nonce guessing).
+  def blog_draft_cache_key(draft_key)
+    "blog_draft:#{current_user.id}:#{draft_key}"
+  end
 
   # The publish button on an unsaved draft submits to #create with a publish
   # flag (HTML), so the draft is created and published in one request.

--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -14,21 +14,21 @@ class BlogPostsController < ApplicationController
     )
   end
 
-  # Opens the editor for an unsaved draft. No row is created on entry — the
-  # first autosave (or publish) persists it via #create.
-  #
-  # The composer POSTs the in-progress body here so it stays out of the URL; we
-  # stash it in the cache under a per-request nonce and redirect to the GET
-  # editor (Turbo follows the redirect and renders the page). Opening the editor
-  # directly (GET) carries over that stashed body once, then starts fresh. The
-  # nonce travels in the redirect URL query, so no session state is needed.
+  # Opens the editor for an unsaved draft (no row until the first autosave via
+  # #create). The composer POSTs the body so it stays out of the URL; we stash it
+  # in the cache under a per-request nonce, then redirect to the GET editor, which
+  # carries the body over once. The nonce rides the redirect query — no session.
   def new
     if request.post?
       draft_key = SecureRandom.hex(8)
-      # User-scoped key so one user can't read another's stashed body, plus a
-      # TTL so abandoned drafts don't linger. The nonce keeps concurrent tabs
-      # from clobbering each other.
-      Rails.cache.write(blog_draft_cache_key(draft_key), params.dig(:post, :body).to_s, expires_in: 1.day)
+      body = params.dig(:post, :body).to_s
+      # SolidCache returns false (not raise) on a failed write; redirect without
+      # the nonce and alert rather than hand the editor a dead key.
+      unless Rails.cache.write(blog_draft_cache_key(draft_key), body, expires_in: 1.week)
+        logger.warn("[BlogPosts#new] draft stash write failed for user=#{current_user.id}")
+        flash[:alert] = t("posts.blog.draft_stash_failed")
+        return redirect_to new_blog_post_path, status: :see_other
+      end
       return redirect_to new_blog_post_path(draft_key: draft_key), status: :see_other
     end
 
@@ -117,17 +117,25 @@ class BlogPostsController < ApplicationController
 
   private
 
-  # Reads and consumes (one-shot) the body stashed by the composer's POST. A
-  # missing nonce or cache miss (expired/consumed) yields a blank body so the
-  # editor starts fresh.
+  # Reads and consumes the body stashed by the composer's POST. No nonce opens a
+  # fresh editor; a nonce with no stash (expired/consumed/failed write) surfaces
+  # a notice instead of silently dropping the in-progress body. Consumption is
+  # best-effort — concurrent GETs may both read before deleting, but that only
+  # duplicates a user's own body into their own tabs.
   def carried_over_draft_body
     draft_key = params[:draft_key]
     return "" if draft_key.blank?
 
     key = blog_draft_cache_key(draft_key)
     body = Rails.cache.read(key)
+    if body.nil?
+      logger.warn("[BlogPosts#new] draft stash miss for user=#{current_user.id} key=#{draft_key}")
+      flash.now[:notice] = t("posts.blog.draft_expired")
+      return ""
+    end
+
     Rails.cache.delete(key)
-    body.to_s
+    body
   end
 
   # Namespaced under the current user so a stashed body is only ever readable by

--- a/app/views/posts/show.rb
+++ b/app/views/posts/show.rb
@@ -4,6 +4,7 @@ class Views::Posts::Show < Views::Base
   include Phlex::Rails::Helpers::ContentFor
   include Phlex::Rails::Helpers::LinkTo
   include Phlex::Rails::Helpers::ButtonTo
+  include Phlex::Rails::Helpers::Sanitize
   include PhlexIcons
 
   def initialize(posts:, liked_post_ids: [], boosted_post_ids: [])
@@ -75,10 +76,11 @@ class Views::Posts::Show < Views::Base
       div(class: "text-sm text-content-muted") do
         plain I18n.l(root.published_at || root.created_at, format: :short)
       end
-      # body is allowlist-sanitized on save (HtmlSanitizable#sanitize_body).
-      # Phlex's `raw` only accepts html_safe input, so the marker is required.
+      # body is allowlist-sanitized on save (HtmlSanitizable#sanitize_body); we
+      # sanitize again at render time as defense in depth. `sanitize` returns a
+      # SafeBuffer, so `raw` accepts it without an explicit html_safe marker.
       div(class: "post-content prose prose-lg dark:prose-invert max-w-none text-content wrap-break-word") do
-        raw root.body.html_safe
+        raw sanitize(root.body, tags: HtmlSanitizable::ALLOWED_TAGS)
       end
       owner_controls(root)
     end

--- a/app/views/posts/show.rb
+++ b/app/views/posts/show.rb
@@ -80,7 +80,7 @@ class Views::Posts::Show < Views::Base
       # sanitize again at render time as defense in depth. `sanitize` returns a
       # SafeBuffer, so `raw` accepts it without an explicit html_safe marker.
       div(class: "post-content prose prose-lg dark:prose-invert max-w-none text-content wrap-break-word") do
-        raw sanitize(root.body, tags: HtmlSanitizable::ALLOWED_TAGS)
+        raw sanitize(root.body.to_s, tags: HtmlSanitizable::ALLOWED_TAGS)
       end
       owner_controls(root)
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -287,6 +287,8 @@ en:
       read_more: Read full post
       manage_title: Manage blog posts | Ruby-News
       manage_heading: Manage blog posts
+      draft_stash_failed: We couldn't hand your draft to the editor. Please try again.
+      draft_expired: Your carried-over draft was no longer available, so the editor opened blank.
       errors:
         blank_draft: Enter a title or body before saving this draft.
     post_card:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -287,6 +287,8 @@ ja:
       read_more: 本文を読む
       manage_title: ブログ記事の管理 | Ruby-News
       manage_heading: ブログ記事の管理
+      draft_stash_failed: 下書きをエディタに引き継げませんでした。もう一度お試しください。
+      draft_expired: 引き継ぐ下書きが見つからなかったため、空のエディタで開きました。
       errors:
         blank_draft: 下書きを保存するにはタイトルまたは本文を入力してください。
     post_card:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -287,6 +287,8 @@ ko:
       read_more: 원문 읽기
       manage_title: 블로그 글 관리 | Ruby-News
       manage_heading: 블로그 글 관리
+      draft_stash_failed: 편집기로 초안을 넘기지 못했습니다. 다시 시도해 주세요.
+      draft_expired: 이어받을 초안이 남아 있지 않아 빈 편집기로 열었습니다.
       errors:
         blank_draft: 제목이나 본문 중 하나는 입력해야 합니다.
     post_card:

--- a/test/controllers/blog_posts_controller_test.rb
+++ b/test/controllers/blog_posts_controller_test.rb
@@ -31,18 +31,22 @@ class BlogPostsControllerTest < ActionDispatch::IntegrationTest
   test "new editor prefills body carried from the composer" do
     sign_in @user
 
-    assert_no_difference -> { Post.blog.count } do
-      # POST keeps the body out of the URL; #new stashes it with a per-request
-      # nonce so concurrent tabs don't clobber each other, then redirects to the
-      # GET editor, which prefills it.
-      post new_blog_post_url, params: { post: { body: "<p>이관된 본문</p>" } }
+    # The test env uses :null_store, which never retains writes. Swap in a real
+    # in-memory store just for this case so the stash-then-read round-trips.
+    with_memory_cache do
+      assert_no_difference -> { Post.blog.count } do
+        # POST keeps the body out of the URL; #new stashes it in the cache with a
+        # per-request nonce so concurrent tabs don't clobber each other, then
+        # redirects to the GET editor, which prefills it.
+        post new_blog_post_url, params: { post: { body: "<p>이관된 본문</p>" } }
 
-      assert_response :see_other
-      follow_redirect!
+        assert_response :see_other
+        follow_redirect!
+      end
+
+      assert_response :success
+      assert_includes response.body, "이관된 본문"
     end
-
-    assert_response :success
-    assert_includes response.body, "이관된 본문"
   end
 
   test "first autosave creates the draft and returns the persisted urls" do
@@ -346,5 +350,17 @@ class BlogPostsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_includes response.body, I18n.t("profiles.blog_list.trash_empty")
+  end
+
+  private
+
+  # test.rb pins the cache to :null_store, so any code under test that relies on
+  # Rails.cache round-tripping needs a real store for the duration of the block.
+  def with_memory_cache
+    original = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    yield
+  ensure
+    Rails.cache = original
   end
 end

--- a/test/controllers/blog_posts_controller_test.rb
+++ b/test/controllers/blog_posts_controller_test.rb
@@ -49,6 +49,58 @@ class BlogPostsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "a stashed draft body is not readable by another user" do
+    # The cache key is namespaced by current_user.id, so the nonce alone must not
+    # let a different account read the body user A stashed. This is the single
+    # property that distinguishes the user-scoped cache from a shared stash.
+    with_memory_cache do
+      sign_in @user
+      post new_blog_post_url, params: { post: { body: "<p>john의 비밀 초안</p>" } }
+
+      assert_response :see_other
+      draft_key = Rack::Utils.parse_query(URI(response.location).query)["draft_key"]
+
+      assert_predicate draft_key, :present?
+
+      sign_out @user
+      sign_in @other_user
+
+      assert_no_difference -> { Post.blog.count } do
+        get new_blog_post_url(draft_key: draft_key)
+      end
+
+      assert_response :success
+      assert_not_includes response.body, "john의 비밀 초안"
+    end
+  end
+
+  test "opening the editor with an unknown draft key notifies instead of silently blanking" do
+    sign_in @user
+
+    # A nonce with no matching stash (expired, consumed, or a failed write) must
+    # not drop the user into a blank editor with no explanation.
+    with_memory_cache do
+      get new_blog_post_url(draft_key: "deadbeef")
+    end
+
+    assert_response :success
+    assert_includes response.body, I18n.t("posts.blog.draft_expired")
+  end
+
+  test "a failed stash write redirects to a blank editor with an alert instead of a dead nonce" do
+    sign_in @user
+
+    # SolidCache returns false (not raise) when a write can't land; the composer
+    # must not hand the editor a nonce that resolves to nothing.
+    Rails.cache.stub(:write, false) do
+      post new_blog_post_url, params: { post: { body: "<p>본문</p>" } }
+    end
+
+    assert_response :see_other
+    assert_nil Rack::Utils.parse_query(URI(response.location).query)["draft_key"]
+    assert_equal I18n.t("posts.blog.draft_stash_failed"), flash[:alert]
+  end
+
   test "first autosave creates the draft and returns the persisted urls" do
     sign_in @user
 
@@ -356,11 +408,9 @@ class BlogPostsControllerTest < ActionDispatch::IntegrationTest
 
   # test.rb pins the cache to :null_store, so any code under test that relies on
   # Rails.cache round-tripping needs a real store for the duration of the block.
-  def with_memory_cache
-    original = Rails.cache
-    Rails.cache = ActiveSupport::Cache::MemoryStore.new
-    yield
-  ensure
-    Rails.cache = original
+  # Rails.stub restores the original store on block exit and avoids the global
+  # reassignment footgun if the suite ever moves to thread-based parallelism.
+  def with_memory_cache(&)
+    Rails.stub(:cache, ActiveSupport::Cache::MemoryStore.new, &)
   end
 end

--- a/test/integration/rendered_body_sanitization_test.rb
+++ b/test/integration/rendered_body_sanitization_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# SEC-02 defense-in-depth: every UGC body render site sanitizes at render time
+# with HtmlSanitizable::ALLOWED_TAGS, independent of the save-time sanitize.
+#
+# Bodies are written with update_column so they bypass the before_save
+# sanitize_body callback — this simulates a row that reached the DB with unsafe
+# markup (pre-existing data, a future write path, or the save-time guard being
+# weakened). If a render site drops its sanitize call or widens the allowlist,
+# the disallowed tag survives and these tests fail.
+class RenderedBodySanitizationTest < ActionDispatch::IntegrationTest
+  # <p> is allowed and must survive; <iframe> is disallowed, so the whole tag —
+  # including its src marker — must be pruned. (An iframe is used rather than a
+  # script tag because the sanitizer strips the tag but keeps a script tag's text
+  # content, whereas an iframe's src lives in an attribute that vanishes with it.)
+  PAYLOAD = %(<p>safe body</p><iframe src="//evil.test/c2-xss"></iframe>)
+  DISALLOWED_MARKER = "evil.test"
+
+  test "blog show (Views::Posts::Show) sanitizes the root body at render time" do
+    posts(:blog_published).update_column(:body, PAYLOAD)
+
+    get user_profile_blog_post_url(username: users(:john).username, slug: "lf-published-fixture")
+
+    assert_response :success
+    assert_includes response.body, "safe body"
+    assert_not_includes response.body, DISALLOWED_MARKER
+  end
+
+  test "post show (Components::Posts::PostCard) sanitizes the body at render time" do
+    posts(:short_with_article).update_column(:body, PAYLOAD)
+
+    get post_url("lf-short-fixture")
+
+    assert_response :success
+    assert_includes response.body, "safe body"
+    assert_not_includes response.body, DISALLOWED_MARKER
+  end
+
+  test "article comments (Components::Comments::Comment) sanitize the body at render time" do
+    posts(:comment_post).update_column(:body, PAYLOAD)
+
+    get article_url("ruby-3-4-features")
+
+    assert_response :success
+    assert_includes response.body, "safe body"
+    assert_not_includes response.body, DISALLOWED_MARKER
+  end
+end


### PR DESCRIPTION
## 개요

이슈 #841의 두 보안 심층방어 항목을 처리합니다.

Closes #841

## SEC-01 (Medium) — Bloated Session 해소

블로그 초안 본문을 쿠키 세션 대신 `Rails.cache`에 저장합니다.

- `session[:blog_draft_bodies]` 해시를 **완전히 제거** → 쿠키 4KB 한도 초과 위험 해소
- user-scoped 캐시 키 `"blog_draft:#{current_user.id}:#{draft_key}"` 로 타 사용자 캐시 접근 차단 (심층방어)
- `expires_in: 1.day` TTL, read 직후 `delete`로 1회성 소비 유지
- 키 문자열은 `blog_draft_cache_key` private 헬퍼로 추출 (write/read/delete 일치)

## SEC-02 (Low) — 렌더 시점 sanitize 심층방어 일관화

Post 본문 3개 렌더 지점을 `articles/show.rb` 패턴에 맞춰 렌더 시점에도 sanitize 적용합니다.

- `raw @x.body.html_safe` → `raw sanitize(..., tags: HtmlSanitizable::ALLOWED_TAGS)`
- 대상: `post_card.rb`, `comments/comment.rb`, `views/posts/show.rb`
- 각 파일에 `include Phlex::Rails::Helpers::Sanitize` 추가
- 저장 시 `HtmlSanitizable` sanitize에 더해 동일 allowlist로 렌더 시 이중방어

## 테스트

- test 환경 `cache_store = :null_store` 함정을 피하기 위해, prefill 검증 테스트만 `with_memory_cache` 헬퍼(`ensure`로 `Rails.cache` 원복)로 감쌈. `test.rb`는 미변경.
- `bin/rails test` 결과: **62 runs, 297 assertions, 0 failures, 0 errors**

## 참고

- 마이그레이션 불필요
- `post_permalink_path` route 경고는 이번 변경과 무관한 선재 이슈

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **보안 개선**
  * 댓글, 게시물 카드, 게시물 본문 표시 시 UGC가 허용된 HTML만 남기도록 렌더링 단계에서 정제를 강화했습니다.
  * 악성 마크업이 화면에 노출되지 않도록 방어를 보강했습니다.

* **기능 개선**
  * 글 작성(에디터) 단계에서 초안 본문이 안정적으로 이어지도록, 임시 저장 후 만료되는 캐시 기반 전달로 변경했습니다.
  * 초안 전달 실패/만료 시 안내 문구를 추가했습니다.

* **테스트**
  * 렌더링 구간별 정제 보장을 검증하는 통합 테스트와 초안 전달 테스트 시나리오를 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->