### PR TITLE
[Audit][MODEL-02] 폴리모픽 로딩 스코프 추출: Like/Boost.for_actor

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -50,14 +50,14 @@ class ProfilesController < ApplicationController
   def likes
     @pagy, page_likes = pagy(Like.for_actor(@user.federails_actor))
 
-    @likeables = Profiles::PolymorphicActivity.resolve(page_likes.map { |l| [ l.likeable_type, l.likeable_id ] })
+    @likeables = Profiles::PolymorphicActivity.resolve(page_likes.pluck(:likeable_type, :likeable_id))
     render_activity_page(:likes)
   end
 
   def boosts
     @pagy, page_boosts = pagy(Boost.for_actor(@user.federails_actor))
 
-    @boostables = Profiles::PolymorphicActivity.resolve(page_boosts.map { |b| [ b.boostable_type, b.boostable_id ] })
+    @boostables = Profiles::PolymorphicActivity.resolve(page_boosts.pluck(:boostable_type, :boostable_id))
     render_activity_page(:boosts)
   end
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -48,18 +48,14 @@ class ProfilesController < ApplicationController
   end
 
   def likes
-    likes = Like.where(actor: @user.federails_actor, likeable_type: %w[Article Post])
-                .order(created_at: :desc)
-    @pagy, page_likes = pagy(likes)
+    @pagy, page_likes = pagy(Like.for_actor(@user.federails_actor))
 
     @likeables = Profiles::PolymorphicActivity.resolve(page_likes.map { |l| [ l.likeable_type, l.likeable_id ] })
     render_activity_page(:likes)
   end
 
   def boosts
-    boosts = Boost.where(actor: @user.federails_actor, boostable_type: %w[Article Post])
-                  .order(created_at: :desc)
-    @pagy, page_boosts = pagy(boosts)
+    @pagy, page_boosts = pagy(Boost.for_actor(@user.federails_actor))
 
     @boostables = Profiles::PolymorphicActivity.resolve(page_boosts.map { |b| [ b.boostable_type, b.boostable_id ] })
     render_activity_page(:boosts)

--- a/app/models/boost.rb
+++ b/app/models/boost.rb
@@ -13,6 +13,13 @@ class Boost < ApplicationRecord
   after_create_commit  :enqueue_thumbnail_generation
   after_destroy_commit :publish_undo_activity,  if: :local_actor?
 
+  # Article/Post boosts for a profile activity feed, newest first.
+  scope :for_actor, ->(actor) {
+    return none if actor.nil?
+
+    where(actor: actor, boostable_type: %w[Article Post]).order(created_at: :desc)
+  }
+
   class << self
     #: (booster: (User | Federails::Actor)?, boostable_type: String, boostable_ids: Array[Integer]) -> Array[Integer]
     def boosted_ids_for(booster:, boostable_type:, boostable_ids:)

--- a/app/models/boost.rb
+++ b/app/models/boost.rb
@@ -13,14 +13,16 @@ class Boost < ApplicationRecord
   after_create_commit  :enqueue_thumbnail_generation
   after_destroy_commit :publish_undo_activity,  if: :local_actor?
 
-  # Article/Post boosts for a profile activity feed, newest first.
-  scope :for_actor, ->(actor) {
-    return none if actor.nil?
-
-    where(actor: actor, boostable_type: %w[Article Post]).order(created_at: :desc)
-  }
-
   class << self
+    # Article/Post boosts for a profile activity feed, newest first.
+    # A class method (not a scope) so the nil early-return is unambiguous.
+    #: ((User | Federails::Actor)?) -> ActiveRecord::Relation
+    def for_actor(actor)
+      return none if actor.nil?
+
+      where(actor: actor, boostable_type: %w[Article Post]).order(created_at: :desc)
+    end
+
     #: (booster: (User | Federails::Actor)?, boostable_type: String, boostable_ids: Array[Integer]) -> Array[Integer]
     def boosted_ids_for(booster:, boostable_type:, boostable_ids:)
       actor = resolve_actor(booster)

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -13,14 +13,16 @@ class Like < ApplicationRecord
   after_create_commit  :enqueue_thumbnail_generation
   after_destroy_commit :publish_undo_activity,  if: :local_actor?
 
-  # Article/Post likes for a profile activity feed, newest first.
-  scope :for_actor, ->(actor) {
-    return none if actor.nil?
-
-    where(actor: actor, likeable_type: %w[Article Post]).order(created_at: :desc)
-  }
-
   class << self
+    # Article/Post likes for a profile activity feed, newest first.
+    # A class method (not a scope) so the nil early-return is unambiguous.
+    #: ((User | Federails::Actor)?) -> ActiveRecord::Relation
+    def for_actor(actor)
+      return none if actor.nil?
+
+      where(actor: actor, likeable_type: %w[Article Post]).order(created_at: :desc)
+    end
+
     #: (liker: (User | Federails::Actor)?, likeable_type: String, likeable_ids: Array[Integer]) -> Array[Integer]
     def liked_ids_for(liker:, likeable_type:, likeable_ids:)
       actor = resolve_actor(liker)

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -13,6 +13,13 @@ class Like < ApplicationRecord
   after_create_commit  :enqueue_thumbnail_generation
   after_destroy_commit :publish_undo_activity,  if: :local_actor?
 
+  # Article/Post likes for a profile activity feed, newest first.
+  scope :for_actor, ->(actor) {
+    return none if actor.nil?
+
+    where(actor: actor, likeable_type: %w[Article Post]).order(created_at: :desc)
+  }
+
   class << self
     #: (liker: (User | Federails::Actor)?, likeable_type: String, likeable_ids: Array[Integer]) -> Array[Integer]
     def liked_ids_for(liker:, likeable_type:, likeable_ids:)

--- a/spec/models/boost_spec.rb
+++ b/spec/models/boost_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Boost, type: :model do
+  set_fixture_class federails_actors: Federails::Actor
+  fixtures :users, :articles, :sites, :federails_actors
+
+  describe '.for_actor' do
+    let(:actor) { federails_actors(:john_actor) }
+    let(:other_actor) { federails_actors(:jane_actor) }
+    let(:article) { articles(:ruby_article) }
+    let(:other_article) { articles(:similar_article) }
+
+    it 'returns Article/Post boosts belonging to the given actor, newest first' do
+      older = Boost.create!(actor: actor, boostable: other_article, created_at: 2.days.ago)
+      newer = Boost.create!(actor: actor, boostable: article, created_at: 1.day.ago)
+
+      expect(Boost.for_actor(actor)).to eq([ newer, older ])
+    end
+
+    it 'excludes boosts from other actors' do
+      mine = Boost.create!(actor: actor, boostable: article)
+      Boost.create!(actor: other_actor, boostable: other_article)
+
+      expect(Boost.for_actor(actor)).to eq([ mine ])
+    end
+
+    it 'returns none when actor is nil' do
+      Boost.create!(actor: actor, boostable: article)
+
+      expect(Boost.for_actor(nil)).to be_empty
+    end
+  end
+end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Like, type: :model do
+  set_fixture_class federails_actors: Federails::Actor
+  fixtures :users, :articles, :sites, :federails_actors
+
+  describe '.for_actor' do
+    let(:actor) { federails_actors(:john_actor) }
+    let(:other_actor) { federails_actors(:jane_actor) }
+    let(:article) { articles(:ruby_article) }
+    let(:other_article) { articles(:similar_article) }
+
+    it 'returns Article/Post likes belonging to the given actor, newest first' do
+      older = Like.create!(actor: actor, likeable: other_article, created_at: 2.days.ago)
+      newer = Like.create!(actor: actor, likeable: article, created_at: 1.day.ago)
+
+      expect(Like.for_actor(actor)).to eq([ newer, older ])
+    end
+
+    it 'excludes likes from other actors' do
+      mine = Like.create!(actor: actor, likeable: article)
+      Like.create!(actor: other_actor, likeable: other_article)
+
+      expect(Like.for_actor(actor)).to eq([ mine ])
+    end
+
+    it 'returns none when actor is nil' do
+      Like.create!(actor: actor, likeable: article)
+
+      expect(Like.for_actor(nil)).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## 요약

`RAILS_AUDIT_REPORT.md` §4 Models의 **MODEL-02** (Medium) 대응. `ProfilesController#likes` / `#boosts`에 흩어져 있던 다형성 로딩 쿼리(actor 필터 + Article/Post 타입 제한 + 정렬)를 모델 스코프로 이관해 재사용·테스트 가능하게 만들었습니다.

> CTRL-01(#850)에서 이미 `Profiles::PolymorphicActivity.resolve`로 타입 분해/로딩을 추출했으므로, 남은 인라인 쿼리 부분을 스코프로 마무리합니다.

## 변경 사항

- `Like.for_actor(actor)` / `Boost.for_actor(actor)` 스코프 추가
  - actor 필터 + `%w[Article Post]` 타입 제한 + `created_at DESC` 정렬 캡슐화
  - `actor`가 `nil`이면 `none` 반환 (기존 `where(actor: nil)`과 동일하게 빈 결과, 더 명시적)
- `ProfilesController#likes`, `#boosts`를 스코프 사용으로 단순화 (인라인 `Like.where` / `Boost.where` 제거)
- `spec/models/like_spec.rb`, `spec/models/boost_spec.rb` 추가 — actor 스코핑, 최신순 정렬, nil 처리 검증

## 검증

- `bundle exec rspec` (모델 스펙 + likes/boosts 요청 스펙): 22 examples, 0 failures
- `rails 'ai:tool[validate]'`: 통과
- RuboCop: 위반 없음

Refs #842 (MODEL-02)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 프로필의 좋아요 및 부스트 활동 목록을 해당 사용자 기준으로 필터링해 정확히 표시하도록 개선했습니다.
  * 좋아요/부스트 활동은 생성일 기준 최신순으로 정렬해 일관되게 제공합니다.
  * 관련 대상이 없거나 식별 정보가 없는 경우 빈 목록으로 처리됩니다.
* **테스트**
  * 좋아요 및 부스트의 사용자별 필터링, 최신순 정렬, nil 입력 시 빈 결과 처리를 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->