### PR TITLE
[Audit][MODEL-01] Article/Post 코어 축소: 인바운드 AP 파싱·마크다운 추출

### DIFF
--- a/app/functions/articles/markdown.rb
+++ b/app/functions/articles/markdown.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Renders an Article as Markdown (used by the `.md` response format). Kept out of
+# the Article model so its I18n-heavy display formatting doesn't add to the
+# model's surface; reads only the article's public locale-aware display methods.
+module Articles
+  module Markdown
+    class << self
+      #: (Article article) -> String
+      def call(article)
+        [
+          "# #{article.display_title}\n",
+          "- **#{I18n.t('articles.markdown.source_url')}**: #{article.url}",
+          "- **#{I18n.t('articles.markdown.ruby_news_url')}**: #{Rails.application.routes.url_helpers.article_url(article)}",
+          (article.published_at.present? ? "- **#{I18n.t('articles.markdown.published_at')}**: #{article.published_at}" : nil),
+          summary_key_section(article),
+          introduction_section(article),
+          body_section(article),
+          conclusion_section(article)
+        ].compact.join("\n")
+      end
+
+      private
+
+      #: (Article article) -> String?
+      def summary_key_section(article)
+        return if article.display_summary_key.blank?
+
+        "\n## #{I18n.t('articles.markdown.summary_heading')}\n" \
+          "#{article.display_summary_key.map { |item| "- #{item}" }.join("\n")}"
+      end
+
+      #: (Article article) -> String?
+      def introduction_section(article)
+        detail = article.display_summary_detail
+        return unless detail.is_a?(Hash) && detail["introduction"].present?
+
+        "\n## #{I18n.t('articles.markdown.introduction_heading')}\n#{detail['introduction']}"
+      end
+
+      #: (Article article) -> String?
+      def body_section(article)
+        return if article.display_summary_body.blank?
+
+        "\n## #{I18n.t('articles.markdown.body_heading')}\n#{article.display_summary_body}"
+      end
+
+      #: (Article article) -> String?
+      def conclusion_section(article)
+        detail = article.display_summary_detail
+        return unless detail.is_a?(Hash) && detail["conclusion"].present?
+
+        "\n## #{I18n.t('articles.markdown.conclusion_heading')}\n#{detail['conclusion']}"
+      end
+    end
+  end
+end

--- a/app/functions/articles/markdown.rb
+++ b/app/functions/articles/markdown.rb
@@ -8,7 +8,7 @@ module Articles
   module Markdown
     class << self
       #: (Article article) -> String
-      def call(article)
+      def render(article)
         [
           "# #{article.display_title}\n",
           "- **#{I18n.t('articles.markdown.source_url')}**: #{article.url}",

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -159,18 +159,9 @@ class Article < ApplicationRecord
 
   # ── Public Instance Methods ──────────────────────────────────────────
 
-  # #: () -> String
+  #: () -> String
   def to_markdown
-    [
-      "# #{display_title}\n",
-      "- **#{I18n.t('articles.markdown.source_url')}**: #{url}",
-      "- **#{I18n.t('articles.markdown.ruby_news_url')}**: #{Rails.application.routes.url_helpers.article_url(self)}",
-      (published_at.present? ? "- **#{I18n.t('articles.markdown.published_at')}**: #{published_at}" : nil),
-      (display_summary_key.present? ? "\n## #{I18n.t('articles.markdown.summary_heading')}\n#{display_summary_key.map { |item| "- #{item}" }.join("\n")}" : nil),
-      (display_summary_detail.is_a?(Hash) && display_summary_detail["introduction"].present? ? "\n## #{I18n.t('articles.markdown.introduction_heading')}\n#{display_summary_detail['introduction']}" : nil),
-      (display_summary_body.present? ? "\n## #{I18n.t('articles.markdown.body_heading')}\n#{display_summary_body}" : nil),
-      (display_summary_detail.is_a?(Hash) && display_summary_detail["conclusion"].present? ? "\n## #{I18n.t('articles.markdown.conclusion_heading')}\n#{display_summary_detail['conclusion']}" : nil)
-    ].compact.join("\n")
+    Articles::Markdown.call(self)
   end
 
   def generate_metadata #: void

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -161,7 +161,7 @@ class Article < ApplicationRecord
 
   #: () -> String
   def to_markdown
-    Articles::Markdown.call(self)
+    Articles::Markdown.render(self)
   end
 
   def generate_metadata #: void

--- a/app/models/concerns/posts/federation_ingest.rb
+++ b/app/models/concerns/posts/federation_ingest.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Inbound ActivityPub parsing for Post: turns a remote Note hash into local
+# attributes, resolving the reply target (article comment, post reply, or
+# federated parent) and extracting body/attachments/hashtags.
+#
+# Symmetric to the outbound serialization in Posts::Federation. Kept out of Post
+# itself so the model stays focused on persistence, enums, scopes, and callbacks.
+module Posts::FederationIngest
+  extend ActiveSupport::Concern
+
+  class_methods do
+    #: (Hash[String, untyped]) -> Hash[Symbol, untyped]
+    def from_activitypub_object(hash)
+      in_reply_to = hash["inReplyTo"].to_s
+      attachments = Array.wrap(hash["attachment"]).select { |a| a.is_a?(Hash) && (a["type"] == "Document" || a["type"] == "Image") }
+
+      object = {
+        federated_url: hash["id"],
+        url: hash["url"],
+        title: hash["summary"].presence,
+        body: extract_body_from_activitypub_object(hash, attachments:)
+      }
+
+      object.merge!(reply_attributes(in_reply_to)) if in_reply_to.present?
+
+      # Mastodon 이미지 첨부 파싱
+      object[:media_attachments] = attachments.map do |a|
+        { "url" => a["url"], "mediaType" => a["mediaType"], "name" => a["name"] }.compact
+      end
+
+      # Mastodon 해시태그 파싱
+      hashtags = Array.wrap(hash["tag"]).select { |t| t.is_a?(Hash) && t["type"] == "Hashtag" }
+      object[:tag_list] = hashtags.map { |t| t["name"].to_s.delete_prefix("#") }.uniq.join(", ") if hashtags.any?
+
+      object
+    end
+
+    private
+
+    # Resolves the reply target (article comment, post reply, or federated
+    # parent) from an inReplyTo URL into attributes for from_activitypub_object.
+    # Inbound replies to an article are typed :comment so they stay in the
+    # `comments` scope instead of defaulting to :short.
+    #: (String) -> Hash[Symbol, untyped]
+    def reply_attributes(in_reply_to)
+      attrs = reply_target_attributes(in_reply_to)
+      attrs[:post_type] = :comment if attrs[:article_id].present?
+      attrs
+    end
+
+    #: (String) -> Hash[Symbol, untyped]
+    def reply_target_attributes(in_reply_to)
+      # Numeric-id branches only for local hosts: a remote UUID like
+      # /articles/019f... would otherwise capture leading digits as a bogus
+      # local id → FK violation.
+      if local_reply_target?(in_reply_to) && (article_id = in_reply_to[%r{/articles/(\d+)}, 1])
+        { article_id: article_id }
+      elsif local_reply_target?(in_reply_to) && (post_id = in_reply_to[%r{/posts/(\d+)}, 1])
+        { parent_id: post_id, article_id: Post.where(id: post_id).pick(:article_id) }
+      elsif (parent = Post.find_by(federated_url: in_reply_to))
+        { parent_id: parent.id, article_id: parent.article_id }
+      else
+        # Unresolved inReplyTo: stored standalone — log so orphans are visible.
+        logger.debug { "reply_target_attributes: unresolved inReplyTo #{in_reply_to.inspect}; storing reply without parent/article" }
+        {}
+      end
+    end
+
+    # Exact host match, not substring: a URL merely embedding a local host
+    # (ruby-news.dev.attacker.example) must not count as local. The app serves
+    # both locale hosts, so Hosts.local_host? is authoritative; the configured
+    # routing host is a fallback for envs served elsewhere (test on example.com).
+    #: (String) -> bool
+    def local_reply_target?(in_reply_to)
+      host = URI.parse(in_reply_to).host
+      return false if host.blank?
+      return true if Hosts.local_host?(host)
+
+      configured_host = Rails.application.routes.default_url_options[:host]
+      return host == configured_host if configured_host.present?
+
+      # Blank routing host is a misconfiguration; log so local replies aren't
+      # silently reclassified as remote and orphaned.
+      logger.error { "local_reply_target? cannot classify #{in_reply_to.inspect}: #{host.inspect} is not a known app host and default_url_options[:host] is blank" }
+      false
+    rescue URI::InvalidURIError
+      false
+    end
+
+    #: (Hash[String, untyped], attachments: Array[Hash[String, untyped]]) -> String
+    def extract_body_from_activitypub_object(hash, attachments:)
+      localized_content = hash["contentMap"]
+        .then { |content_map| content_map.is_a?(Hash) ? content_map.values : [] }
+        .filter_map { |value| value.to_s.squish.presence }
+        .first
+
+      body = localized_content || hash["content"].to_s.squish.presence || hash["summary"].to_s.squish.presence
+      return body if body.present?
+
+      attachment_names = attachments.filter_map { |attachment| attachment["name"].to_s.squish.presence }
+      attachment_names.join(" · ").presence || I18n.t("posts.remote_attachment_only_body")
+    end
+
+    #: (Hash[String, untyped]) -> bool
+    def handle_federated_object?(hash)
+      in_reply_to = hash["inReplyTo"].to_s
+
+      # inReplyTo가 없으면 원문 → 수락
+      return true if in_reply_to.blank?
+
+      # inReplyTo가 로컬 post 또는 article을 가리키면 수락
+      if local_reply_target?(in_reply_to)
+        return true if in_reply_to.include?("/posts/") || in_reply_to.include?("/articles/")
+      end
+
+      # inReplyTo가 기존 post의 federated_url이면 수락
+      Post.exists?(federated_url: in_reply_to)
+    end
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -13,6 +13,7 @@ class Post < ApplicationRecord
   include HtmlSanitizable
   include Posts::Blog
   include Posts::Federation
+  include Posts::FederationIngest
   include Discard::Model
   include Federails::DataEntity
   include FederailsLikeable
@@ -221,116 +222,5 @@ class Post < ApplicationRecord
   #: () -> String
   def random_slug
     SecureRandom.urlsafe_base64(16)
-  end
-
-  # ── Class Methods ────────────────────────────────────────────────────
-  class << self
-    #: (Hash[String, untyped]) -> Hash[Symbol, untyped]
-    def from_activitypub_object(hash)
-      in_reply_to = hash["inReplyTo"].to_s
-      attachments = Array.wrap(hash["attachment"]).select { |a| a.is_a?(Hash) && (a["type"] == "Document" || a["type"] == "Image") }
-
-      object = {
-        federated_url: hash["id"],
-        url: hash["url"],
-        title: hash["summary"].presence,
-        body: extract_body_from_activitypub_object(hash, attachments:)
-      }
-
-      object.merge!(reply_attributes(in_reply_to)) if in_reply_to.present?
-
-      # Mastodon 이미지 첨부 파싱
-      object[:media_attachments] = attachments.map do |a|
-        { "url" => a["url"], "mediaType" => a["mediaType"], "name" => a["name"] }.compact
-      end
-
-      # Mastodon 해시태그 파싱
-      hashtags = Array.wrap(hash["tag"]).select { |t| t.is_a?(Hash) && t["type"] == "Hashtag" }
-      object[:tag_list] = hashtags.map { |t| t["name"].to_s.delete_prefix("#") }.uniq.join(", ") if hashtags.any?
-
-      object
-    end
-
-    private
-
-    # Resolves the reply target (article comment, post reply, or federated
-    # parent) from an inReplyTo URL into attributes for from_activitypub_object.
-    # Inbound replies to an article are typed :comment so they stay in the
-    # `comments` scope instead of defaulting to :short.
-    #: (String) -> Hash[Symbol, untyped]
-    def reply_attributes(in_reply_to)
-      attrs = reply_target_attributes(in_reply_to)
-      attrs[:post_type] = :comment if attrs[:article_id].present?
-      attrs
-    end
-
-    #: (String) -> Hash[Symbol, untyped]
-    def reply_target_attributes(in_reply_to)
-      # Numeric-id branches only for local hosts: a remote UUID like
-      # /articles/019f... would otherwise capture leading digits as a bogus
-      # local id → FK violation.
-      if local_reply_target?(in_reply_to) && (article_id = in_reply_to[%r{/articles/(\d+)}, 1])
-        { article_id: article_id }
-      elsif local_reply_target?(in_reply_to) && (post_id = in_reply_to[%r{/posts/(\d+)}, 1])
-        { parent_id: post_id, article_id: Post.where(id: post_id).pick(:article_id) }
-      elsif (parent = Post.find_by(federated_url: in_reply_to))
-        { parent_id: parent.id, article_id: parent.article_id }
-      else
-        # Unresolved inReplyTo: stored standalone — log so orphans are visible.
-        logger.debug { "reply_target_attributes: unresolved inReplyTo #{in_reply_to.inspect}; storing reply without parent/article" }
-        {}
-      end
-    end
-
-    # Exact host match, not substring: a URL merely embedding a local host
-    # (ruby-news.dev.attacker.example) must not count as local. The app serves
-    # both locale hosts, so Hosts.local_host? is authoritative; the configured
-    # routing host is a fallback for envs served elsewhere (test on example.com).
-    #: (String) -> bool
-    def local_reply_target?(in_reply_to)
-      host = URI.parse(in_reply_to).host
-      return false if host.blank?
-      return true if Hosts.local_host?(host)
-
-      configured_host = Rails.application.routes.default_url_options[:host]
-      return host == configured_host if configured_host.present?
-
-      # Blank routing host is a misconfiguration; log so local replies aren't
-      # silently reclassified as remote and orphaned.
-      logger.error { "local_reply_target? cannot classify #{in_reply_to.inspect}: #{host.inspect} is not a known app host and default_url_options[:host] is blank" }
-      false
-    rescue URI::InvalidURIError
-      false
-    end
-
-    #: (Hash[String, untyped], attachments: Array[Hash[String, untyped]]) -> String
-    def extract_body_from_activitypub_object(hash, attachments:)
-      localized_content = hash["contentMap"]
-        .then { |content_map| content_map.is_a?(Hash) ? content_map.values : [] }
-        .filter_map { |value| value.to_s.squish.presence }
-        .first
-
-      body = localized_content || hash["content"].to_s.squish.presence || hash["summary"].to_s.squish.presence
-      return body if body.present?
-
-      attachment_names = attachments.filter_map { |attachment| attachment["name"].to_s.squish.presence }
-      attachment_names.join(" · ").presence || I18n.t("posts.remote_attachment_only_body")
-    end
-
-    #: (Hash[String, untyped]) -> bool
-    def handle_federated_object?(hash)
-      in_reply_to = hash["inReplyTo"].to_s
-
-      # inReplyTo가 없으면 원문 → 수락
-      return true if in_reply_to.blank?
-
-      # inReplyTo가 로컬 post 또는 article을 가리키면 수락
-      if local_reply_target?(in_reply_to)
-        return true if in_reply_to.include?("/posts/") || in_reply_to.include?("/articles/")
-      end
-
-      # inReplyTo가 기존 post의 federated_url이면 수락
-      Post.exists?(federated_url: in_reply_to)
-    end
   end
 end

--- a/test/functions/articles/markdown_test.rb
+++ b/test/functions/articles/markdown_test.rb
@@ -22,48 +22,48 @@ class Articles::MarkdownTest < ActiveSupport::TestCase
     }.merge(overrides))
   end
 
-  test "call renders title, source url and ruby-news url" do
-    markdown = Articles::Markdown.call(build_article)
+  test "render includes title, source url and ruby-news url" do
+    markdown = Articles::Markdown.render(build_article)
 
     assert_match "# 테스트 제목", markdown
     assert_match "- **원문 URL**: https://example.com/test", markdown
     assert_match "- **Ruby-News URL**: #{Rails.application.routes.url_helpers.article_url(build_article)}", markdown
   end
 
-  test "call includes published_at line when present" do
-    markdown = Articles::Markdown.call(build_article(published_at: Time.zone.parse("2026-01-02 03:04:05")))
+  test "render includes published_at line when present" do
+    markdown = Articles::Markdown.render(build_article(published_at: Time.zone.parse("2026-01-02 03:04:05")))
 
     assert_match(/- \*\*발행일\*\*: .*2026/, markdown)
   end
 
-  test "call omits published_at line when blank" do
-    markdown = Articles::Markdown.call(build_article(published_at: nil))
+  test "render omits published_at line when blank" do
+    markdown = Articles::Markdown.render(build_article(published_at: nil))
 
     assert_no_match(/\*\*발행일\*\*/, markdown)
   end
 
-  test "call omits summary section when summary_key is blank" do
-    markdown = Articles::Markdown.call(build_article(summary_key: nil, summary_key_ja: nil))
+  test "render omits summary section when summary_key is blank" do
+    markdown = Articles::Markdown.render(build_article(summary_key: nil, summary_key_ja: nil))
 
     assert_no_match(/## 요약/, markdown)
   end
 
-  test "call omits body section when summary_body is blank" do
-    markdown = Articles::Markdown.call(build_article(summary_body: nil, summary_body_ja: nil))
+  test "render omits body section when summary_body is blank" do
+    markdown = Articles::Markdown.render(build_article(summary_body: nil, summary_body_ja: nil))
 
     assert_no_match(/## 본문/, markdown)
   end
 
   # summary_detail is polymorphic; introduction/conclusion only render for a Hash.
-  test "call omits introduction and conclusion when summary_detail is not a Hash" do
-    markdown = Articles::Markdown.call(build_article(summary_detail: "플레인 문자열"))
+  test "render omits introduction and conclusion when summary_detail is not a Hash" do
+    markdown = Articles::Markdown.render(build_article(summary_detail: "플레인 문자열"))
 
     assert_no_match(/## 소개/, markdown)
     assert_no_match(/## 결론/, markdown)
   end
 
-  test "call omits introduction when the introduction key is blank" do
-    markdown = Articles::Markdown.call(build_article(summary_detail: { "conclusion" => "결론만" }))
+  test "render omits introduction when the introduction key is blank" do
+    markdown = Articles::Markdown.render(build_article(summary_detail: { "conclusion" => "결론만" }))
 
     assert_no_match(/## 소개/, markdown)
     assert_match(/## 결론\n결론만/, markdown)

--- a/test/functions/articles/markdown_test.rb
+++ b/test/functions/articles/markdown_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Direct coverage for the extracted Articles::Markdown renderer. The happy path
+# is also exercised via Article#to_markdown in article_test.rb; these tests pin
+# the section-omission and type-guard branches that only live in this module.
+class Articles::MarkdownTest < ActiveSupport::TestCase
+  def build_article(**overrides)
+    Article.new({
+      title: "Test Title",
+      title_ko: "테스트 제목",
+      url: "https://example.com/test",
+      origin_url: "https://example.com/test",
+      host: "example.com",
+      slug: "test-slug",
+      summary_key: [ "핵심 요약 1", "핵심 요약 2" ],
+      summary_detail: { "introduction" => "서론 부분", "conclusion" => "결론 부분" },
+      body: "원본 본문",
+      summary_body: "요약된 마크다운 본문",
+      user: users(:john)
+    }.merge(overrides))
+  end
+
+  test "call renders title, source url and ruby-news url" do
+    markdown = Articles::Markdown.call(build_article)
+
+    assert_match "# 테스트 제목", markdown
+    assert_match "- **원문 URL**: https://example.com/test", markdown
+    assert_match "- **Ruby-News URL**: #{Rails.application.routes.url_helpers.article_url(build_article)}", markdown
+  end
+
+  test "call includes published_at line when present" do
+    markdown = Articles::Markdown.call(build_article(published_at: Time.zone.parse("2026-01-02 03:04:05")))
+
+    assert_match(/- \*\*발행일\*\*: .*2026/, markdown)
+  end
+
+  test "call omits published_at line when blank" do
+    markdown = Articles::Markdown.call(build_article(published_at: nil))
+
+    assert_no_match(/\*\*발행일\*\*/, markdown)
+  end
+
+  test "call omits summary section when summary_key is blank" do
+    markdown = Articles::Markdown.call(build_article(summary_key: nil, summary_key_ja: nil))
+
+    assert_no_match(/## 요약/, markdown)
+  end
+
+  test "call omits body section when summary_body is blank" do
+    markdown = Articles::Markdown.call(build_article(summary_body: nil, summary_body_ja: nil))
+
+    assert_no_match(/## 본문/, markdown)
+  end
+
+  # summary_detail is polymorphic; introduction/conclusion only render for a Hash.
+  test "call omits introduction and conclusion when summary_detail is not a Hash" do
+    markdown = Articles::Markdown.call(build_article(summary_detail: "플레인 문자열"))
+
+    assert_no_match(/## 소개/, markdown)
+    assert_no_match(/## 결론/, markdown)
+  end
+
+  test "call omits introduction when the introduction key is blank" do
+    markdown = Articles::Markdown.call(build_article(summary_detail: { "conclusion" => "결론만" }))
+
+    assert_no_match(/## 소개/, markdown)
+    assert_match(/## 결론\n결론만/, markdown)
+  end
+end

--- a/test/models/concerns/posts/federation_ingest_test.rb
+++ b/test/models/concerns/posts/federation_ingest_test.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Direct coverage for the extracted Posts::FederationIngest concern (inbound
+# ActivityPub parsing). Reply-target resolution is also exercised in
+# post_test.rb; these tests pin the currently-undocumented edge cases:
+# article_id value-type inconsistency, discarded-parent resolution, hashtag
+# prefix handling, and the missing-id path.
+class Posts::FederationIngestTest < ActiveSupport::TestCase
+  def setup
+    @article = articles(:ruby_article)
+    @root_post = posts(:root_post)
+    @comment_post = posts(:comment_post) # post_type :comment, belongs to ruby_article
+    @local_host = Rails.application.routes.default_url_options[:host] || "www.example.com"
+  end
+
+  # ── article_id value type (regex capture vs DB column) ──────────────
+  #
+  # The /articles/N branch yields a String (regex capture) while the
+  # federated-parent branch yields an Integer. Pinned so a future
+  # normalization is a deliberate, visible change.
+
+  test "article_id from a local /articles/ URL is a String" do
+    hash = { "id" => "https://remote.example.com/notes/a", "content" => "댓글",
+             "inReplyTo" => "https://#{@local_host}/articles/#{@article.id}" }
+    result = Post.from_activitypub_object(hash)
+
+    assert_equal @article.id.to_s, result[:article_id]
+    assert_kind_of String, result[:article_id]
+    assert_equal :comment, result[:post_type]
+  end
+
+  test "article_id from a federated parent is an Integer" do
+    parent = Post.create!(body: "미러링된 리모트 기사", federails_actor: federails_actors(:john_actor),
+                          federated_url: "https://hackers.pub/ap/notes/parent-1", article: @article)
+    hash = { "id" => "https://hackers.pub/ap/notes/child-1", "content" => "답글",
+             "inReplyTo" => "https://hackers.pub/ap/notes/parent-1" }
+    result = Post.from_activitypub_object(hash)
+
+    assert_equal parent.id, result[:parent_id]
+    assert_equal @article.id, result[:article_id]
+    assert_kind_of Integer, result[:article_id]
+  end
+
+  # ── discarded parent (verified actual behavior) ─────────────────────
+  #
+  # Post has no `kept` default_scope, so Post.find_by / Post.exists? DO see
+  # soft-deleted rows. A reply to a discarded parent therefore resolves
+  # normally rather than being orphaned. Pinned to lock in the real behavior.
+
+  test "reply to a discarded federated parent still resolves parent_id and article_id" do
+    parent = Post.create!(body: "삭제된 원격 부모", federails_actor: federails_actors(:john_actor),
+                          federated_url: "https://remote.example.com/notes/discarded", article: @article)
+    parent.discard!
+
+    hash = { "id" => "https://remote.example.com/notes/reply-to-discarded", "content" => "답글",
+             "inReplyTo" => "https://remote.example.com/notes/discarded" }
+    result = Post.from_activitypub_object(hash)
+
+    assert_equal parent.id, result[:parent_id]
+    assert_equal @article.id, result[:article_id]
+  end
+
+  test "handle_federated_object? accepts a reply to a discarded parent's federated_url" do
+    parent = Post.create!(body: "삭제된 원격 부모", federails_actor: federails_actors(:john_actor),
+                          federated_url: "https://remote.example.com/notes/discarded-2")
+    parent.discard!
+
+    hash = { "type" => "Note", "inReplyTo" => "https://remote.example.com/notes/discarded-2" }
+
+    assert Post.send(:handle_federated_object?, hash)
+  end
+
+  # ── local /posts/ branch ────────────────────────────────────────────
+
+  test "local /posts/ URL pointing at a comment fills both parent_id and article_id" do
+    hash = { "id" => "https://remote.example.com/notes/b", "content" => "답글",
+             "inReplyTo" => "https://#{@local_host}/posts/#{@comment_post.id}" }
+    result = Post.from_activitypub_object(hash)
+
+    assert_equal @comment_post.id.to_s, result[:parent_id]
+    assert_equal @comment_post.article_id, result[:article_id]
+  end
+
+  # ── hashtag parsing ─────────────────────────────────────────────────
+
+  test "hashtags are stripped of leading # deduplicated and comma-joined" do
+    hash = { "id" => "https://remote.example.com/notes/tags", "content" => "본문",
+             "tag" => [
+               { "type" => "Hashtag", "name" => "#ruby" },
+               { "type" => "Hashtag", "name" => "rails" },
+               { "type" => "Hashtag", "name" => "#ruby" },
+               { "type" => "Mention", "name" => "@someone" }
+             ] }
+    result = Post.from_activitypub_object(hash)
+
+    assert_equal "ruby, rails", result[:tag_list]
+  end
+
+  test "tag_list is absent when there are no hashtags" do
+    hash = { "id" => "https://remote.example.com/notes/notags", "content" => "본문" }
+    result = Post.from_activitypub_object(hash)
+
+    assert_not result.key?(:tag_list)
+  end
+
+  # ── federated_url / missing id ──────────────────────────────────────
+
+  test "federated_url mirrors the object id and is nil when id is missing" do
+    with_id = Post.from_activitypub_object({ "id" => "https://remote.example.com/notes/c", "content" => "본문" })
+    without_id = Post.from_activitypub_object({ "content" => "본문" })
+
+    assert_equal "https://remote.example.com/notes/c", with_id[:federated_url]
+    assert_nil without_id[:federated_url]
+  end
+
+  # ── no inReplyTo → no reply attributes ──────────────────────────────
+
+  test "an object without inReplyTo carries no reply attributes" do
+    result = Post.from_activitypub_object({ "id" => "https://remote.example.com/notes/root", "content" => "원문" })
+
+    assert_not result.key?(:parent_id)
+    assert_not result.key?(:article_id)
+    assert_not result.key?(:post_type)
+  end
+end


### PR DESCRIPTION
## 요약

`RAILS_AUDIT_REPORT.md` §4 Models의 **MODEL-01** (Medium) 대응. god node로 비대해진 `Article`/`Post`에서 응집도 높은 관심사를 **인터페이스 변경 없이** concern/functions 계층으로 이관합니다. 감사 리포트 권장(“이미 있는 concern 분리 패턴 지속 + 표시 로직은 presenter/functions로”)을 그대로 따릅니다.

## 변경 사항

### Post (336 → 226줄, −110)
- 인바운드 ActivityPub 파싱 `class << self` 블록 전체(`from_activitypub_object` + `reply_attributes` / `reply_target_attributes` / `local_reply_target?` / `extract_body_from_activitypub_object` / `handle_federated_object?`)를 신규 concern **`Posts::FederationIngest`** 로 분리.
- 기존 아웃바운드 직렬화 concern `Posts::Federation`과 **대칭 구조**(inbound/outbound).
- `class_methods do` 로 이관해 `Post.from_activitypub_object`(public) / 나머지(private) **가시성 동일**하게 유지 → 호출부·테스트 변경 없음.

### Article
- I18n 위주의 `to_markdown` 표시 로직을 **`Articles::Markdown`** 함수 모듈로 이관하고, 모델은 위임(`Articles::Markdown.call(self)`)만 유지.
- `.md` 응답(`render markdown: @article`)은 `Article#to_markdown` 인터페이스 유지로 그대로 동작. 옮기면서 인라인 삼항 4개를 명확한 섹션 메서드로 정리.

> youtube_id/update_slug 등 URL·slug 로직은 `is_youtube?`가 동적으로 정의돼 있어 이번 범위에서 제외(별도 후속 가능).

## 검증

- `bin/rails test`: **919 runs, 0 failures** (post/article 테스트 163건 포함, 기존 커버리지가 이관 로직 전체를 검증)
- `bundle exec rspec`: **53 examples, 0 failures**
- 가시성 확인: `Post.from_activitypub_object` public / `handle_federated_object?`·`reply_target_attributes` private 유지
- `rails 'ai:tool[validate]'` 통과, RuboCop 위반 없음

Refs #842 (MODEL-01)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 기사 정보를 제목, 링크, 발행일, 요약·본문·소개·결론이 포함된 마크다운으로 제공합니다.
  - ActivityPub 게시물 수신 시 본문, 첨부파일, 해시태그를 자동으로 처리합니다.
  - 게시물 답글의 원문 연결을 지원하며, 로컬 및 페더레이션 게시물에 맞게 답글 관계를 설정합니다.

- **버그 수정**
  - 빈 콘텐츠나 잘못된 형식의 요약 정보가 마크다운에 불필요하게 표시되지 않도록 개선했습니다.
  - 삭제된 게시물에 대한 답글도 올바르게 연결되도록 보완했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->