### PR TITLE
[Audit][CTRL-02] Articles 검색 화면 조합 분리 (#843)

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -25,17 +25,16 @@ class ArticlesController < ApplicationController
       return
     end
 
-    @pagy, @articles = pagy(Articles::Query.index_html(search))
-    suggestions = @articles.empty? && search.present? ? Articles::Search.suggest(search) : []
+    search_result = Articles::Search.index_html(search:, pagy: method(:pagy))
     render Views::Articles::Index.new(
-      pagy: @pagy,
-      articles: @articles,
+      pagy: search_result.pagy,
+      articles: search_result.articles,
       sidebar_tags: sidebar_tags,
       search: search,
       source: source,
-      liked_article_ids: liked_article_ids(@articles),
-      boosted_article_ids: boosted_article_ids(@articles),
-      suggestions: suggestions
+      liked_article_ids: liked_article_ids(search_result.articles),
+      boosted_article_ids: boosted_article_ids(search_result.articles),
+      suggestions: search_result.suggestions
     )
   end
 

--- a/app/functions/articles/search.rb
+++ b/app/functions/articles/search.rb
@@ -3,19 +3,25 @@
 
 module Articles
   module Search
-    Index = Data.define(
-      :pagy,        #: untyped
-      :articles,    #: untyped
-      :suggestions  #: untyped
+    # 검색 화면 조합 결과. 모듈명 Search 안에서 `Index`는 "검색 인덱스(데이터 구조)"로
+    # 오독되므로 IndexResult로 명명한다.
+    # 불변식: suggestions는 articles가 비어있고 search가 존재할 때만 비-빈이다.
+    IndexResult = Data.define(
+      :pagy,        #: Pagy
+      :articles,    #: Array[Article]
+      :suggestions  #: Array[String]
     )
 
     class << self
-      #: (String? search, ^(ActiveRecord::Relation) -> [Pagy, Array[Article]] pagy) -> Index
+      #: (String? search, ^(ActiveRecord::Relation) -> [Pagy, Array[Article]] pagy) -> IndexResult
       def index_html(search:, pagy:)
         pagy_result, articles = pagy.call(Articles::Query.index_html(search))
+        # to_a로 미리 로드: empty? 검사(COUNT)와 이후 map(&:id)·뷰 렌더링(SELECT)의
+        # 쿼리 중복을 없애고 RBS 선언(Array[Article])과 일치시킨다.
+        articles = articles.to_a
         suggestions = articles.empty? && search.present? ? suggest(search) : []
 
-        Index.new(pagy: pagy_result, articles:, suggestions:)
+        IndexResult.new(pagy: pagy_result, articles:, suggestions:)
       end
 
       # ── cosine_similarity ──────────────────────────────────────

--- a/app/functions/articles/search.rb
+++ b/app/functions/articles/search.rb
@@ -3,7 +3,17 @@
 
 module Articles
   module Search
+    Index = Data.define(:pagy, :articles, :suggestions)
+
     class << self
+      #: (String? search, ^(ActiveRecord::Relation) -> [Pagy, Array[Article]] pagy) -> Index
+      def index_html(search:, pagy:)
+        pagy_result, articles = pagy.call(Articles::Query.index_html(search))
+        suggestions = articles.empty? && search.present? ? suggest(search) : []
+
+        Index.new(pagy: pagy_result, articles:, suggestions:)
+      end
+
       # ── cosine_similarity ──────────────────────────────────────
       #: (Array[Float]? a, Array[Float]? b) -> Float
       def cosine_similarity(a, b)

--- a/app/functions/articles/search.rb
+++ b/app/functions/articles/search.rb
@@ -3,7 +3,11 @@
 
 module Articles
   module Search
-    Index = Data.define(:pagy, :articles, :suggestions)
+    Index = Data.define(
+      :pagy,        #: untyped
+      :articles,    #: untyped
+      :suggestions  #: untyped
+    )
 
     class << self
       #: (String? search, ^(ActiveRecord::Relation) -> [Pagy, Array[Article]] pagy) -> Index

--- a/docs/superpowers/plans/2026-07-19-issue-843-articles-search-delegation.md
+++ b/docs/superpowers/plans/2026-07-19-issue-843-articles-search-delegation.md
@@ -1,0 +1,81 @@
+# Issue 843 Articles Search Delegation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the articles index behavior unchanged while moving its search-page composition out of `ArticlesController`.
+
+**Architecture:** `Articles::Query` remains the relation builder. `Articles::Search` receives the index request inputs and produces the HTML index view state; it owns source selection, relation pagination, and suggestions. `ArticlesController#index` supplies request and shared presentation dependencies, then renders the returned state.
+
+**Tech Stack:** Rails 8, Ruby 4, Minitest integration tests, Pagy, Phlex.
+
+## Global Constraints
+
+- Preserve the Google source fast path, including its zero Article/Like/Tag query guarantee.
+- Preserve search-term trimming and the existing maximum length.
+- Add no dependencies and do not change routes, schema, or the Phlex view contract.
+- Run Rails semantic validation after every code edit and the PostgreSQL-backed test suite before completion.
+
+---
+
+### Task 1: Lock the index composition boundary with a regression test
+
+**Files:**
+
+- Modify: `test/controllers/articles_controller_test.rb`
+- Test: `test/controllers/articles_controller_test.rb`
+
+**Interfaces:**
+
+- Consumes: `Articles::Search.index_html` (new)
+- Produces: a regression assertion that the controller delegates Ruby-News index composition to `Articles::Search`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add an integration test that stubs `Articles::Search.index_html` and verifies an ordinary index request calls it with the trimmed search term and current page parameters, while preserving a successful response.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bin/rails test test/controllers/articles_controller_test.rb -n /delegates/`
+
+Expected: FAIL because `Articles::Search.index_html` does not exist and the controller still calls `Articles::Query.index_html` directly.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `Articles::Search.index_html(search:, page:, pagy:)`, returning immutable index state that contains `pagy`, `articles`, and `suggestions`. Call it from `ArticlesController#index` only for the Ruby-News source.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bin/rails test test/controllers/articles_controller_test.rb -n /delegates/`
+
+Expected: PASS.
+
+### Task 2: Preserve existing index behavior and validate the refactor
+
+**Files:**
+
+- Modify: `app/functions/articles/search.rb`
+- Modify: `app/controllers/articles_controller.rb`
+- Modify: `test/controllers/articles_controller_test.rb`
+
+**Interfaces:**
+
+- Consumes: `Articles::Query.index_html(search)`, `Articles::Search.suggest(query)`, and the controller's existing Pagy helper.
+- Produces: the existing `Views::Articles::Index` keyword inputs without changing its public contract.
+
+- [ ] **Step 1: Run the focused controller tests**
+
+Run: `bin/rails test test/controllers/articles_controller_test.rb`
+
+Expected: PASS, including Google-source query avoidance and signed-in preload assertions.
+
+- [ ] **Step 2: Validate edited Rails files**
+
+Run: `bin/rails 'ai:tool[validate]' files=app/functions/articles/search.rb,app/controllers/articles_controller.rb level=rails`
+
+Expected: no syntax or Rails semantic errors.
+
+- [ ] **Step 3: Run quality gates**
+
+Run: `bin/rake quality`
+
+Expected: all currently configured gates pass; if an unrelated baseline gate fails, record its number and cause without claiming success.

--- a/docs/superpowers/plans/2026-07-19-issue-843-articles-search-delegation.md
+++ b/docs/superpowers/plans/2026-07-19-issue-843-articles-search-delegation.md
@@ -43,6 +43,8 @@ Expected: FAIL because `Articles::Search.index_html` does not exist and the cont
 
 Add `Articles::Search.index_html(search:, page:, pagy:)`, returning immutable index state that contains `pagy`, `articles`, and `suggestions`. Call it from `ArticlesController#index` only for the Ruby-News source.
 
+> **구현 드리프트:** 실제 구현은 `index_html(search:, pagy:)`로 `page:` 파라미터를 받지 않는다. Pagy가 `request`에서 페이지를 암묵적으로 읽으므로 명시 전달이 불필요하다. 이 문서는 작성 시점의 계획(historical)이다.
+
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `bin/rails test test/controllers/articles_controller_test.rb -n /delegates/`

--- a/sig/generated/functions/articles/search.rbs
+++ b/sig/generated/functions/articles/search.rbs
@@ -2,6 +2,27 @@
 
 module Articles
   module Search
+    # 검색 화면 조합 결과. 모듈명 Search 안에서 `Index`는 "검색 인덱스(데이터 구조)"로
+    # 오독되므로 IndexResult로 명명한다.
+    # 불변식: suggestions는 articles가 비어있고 search가 존재할 때만 비-빈이다.
+    class IndexResult < Data
+      attr_reader pagy(): Pagy
+
+      attr_reader articles(): Array[Article]
+
+      attr_reader suggestions(): Array[String]
+
+      def self.new: (Pagy pagy, Array[Article] articles, Array[String] suggestions) -> instance
+                  | (pagy: Pagy, articles: Array[Article], suggestions: Array[String]) -> instance
+
+      def self.members: () -> [ :pagy, :articles, :suggestions ]
+
+      def members: () -> [ :pagy, :articles, :suggestions ]
+    end
+
+    # : (String? search, ^(ActiveRecord::Relation) -> [Pagy, Array[Article]] pagy) -> IndexResult
+    def self.index_html: (String? search, ^(ActiveRecord::Relation) -> [ Pagy, Array[Article] ] pagy) -> IndexResult
+
     # ── cosine_similarity ──────────────────────────────────────
     # : (Array[Float]? a, Array[Float]? b) -> Float
     def self.cosine_similarity: (Array[Float]? a, Array[Float]? b) -> Float

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -3,6 +3,27 @@
 require "test_helper"
 
 class ArticlesControllerTest < ActionDispatch::IntegrationTest
+  test "Articles::Search exposes the HTML index composition API" do
+    assert_respond_to Articles::Search, :index_html
+  end
+
+  test "GET index delegates Ruby-News result composition to Articles::Search" do
+    calls = []
+    original_index_html = Articles::Search.method(:index_html)
+
+    Articles::Search.stub(:index_html, lambda { |**arguments|
+      calls << arguments
+      original_index_html.call(**arguments)
+    }) do
+      get articles_path, params: { search: "  Ruby  " }
+    end
+
+    assert_response :success
+    assert_equal 1, calls.size
+    assert_equal "Ruby", calls.first[:search]
+    assert_respond_to calls.first[:pagy], :call
+  end
+
   test "GET index defaults to Ruby-News search results" do
     get articles_path
 

--- a/test/functions/articles/search_test.rb
+++ b/test/functions/articles/search_test.rb
@@ -111,6 +111,49 @@ class Articles::SearchTest < ActiveSupport::TestCase
     )
   end
 
+  # ── index_html ──────────────────────────────────────────────────
+
+  test "index_html returns an IndexResult with empty suggestions when search is nil" do
+    pagy = Pagy.new(count: 0, page: 1)
+    result = Articles::Search.index_html(search: nil, pagy: ->(_relation) { [ pagy, [] ] })
+
+    assert_instance_of Articles::Search::IndexResult, result
+    assert_equal pagy, result.pagy
+    assert_equal [], result.articles
+    assert_equal [], result.suggestions
+  end
+
+  test "index_html fills suggestions from suggest when articles empty and search present" do
+    pagy = Pagy.new(count: 0, page: 1)
+    suggest_calls = []
+    Articles::Search.stub(:suggest, ->(query, **) {
+      suggest_calls << query
+      [ "루비", "ruby on rails" ]
+    }) do
+      result = Articles::Search.index_html(search: "루비", pagy: ->(_relation) { [ pagy, [] ] })
+
+      assert_equal [ "루비" ], suggest_calls
+      assert_equal [ "루비", "ruby on rails" ], result.suggestions
+      assert_equal [], result.articles
+    end
+  end
+
+  test "index_html skips suggest when articles present" do
+    pagy = Pagy.new(count: 1, page: 1)
+    article = articles(:ruby_article)
+    suggest_calls = []
+    Articles::Search.stub(:suggest, ->(*) {
+      suggest_calls << :called
+      []
+    }) do
+      result = Articles::Search.index_html(search: "ruby", pagy: ->(_relation) { [ pagy, [ article ] ] })
+
+      assert_equal [], suggest_calls
+      assert_equal [], result.suggestions
+      assert_equal [ article ], result.articles
+    end
+  end
+
   # ── suggest ─────────────────────────────────────────────────────
 
   test "suggest returns empty array for blank query" do


### PR DESCRIPTION
## 변경 사항

- `ArticlesController#index`에서 검색 관계 구성·페이지네이션·제안 생성 책임을 `Articles::Search.index_html`로 이동했습니다.
- 불변 `Data` 결과 객체로 검색 화면 상태를 전달합니다.
- Ruby-News 검색 위임과 검색어 정규화 경계를 회귀 테스트로 고정했습니다.

## 영향

Google 검색 빠른 경로와 기존 Phlex 뷰 계약은 유지됩니다.

Closes #843

## 검증

- `bin/rails test test/controllers/articles_controller_test.rb`
  - 19 runs, 142 assertions, 0 failures
- Rails 의미 검증 통과
- 대상 Metrics RuboCop 검사: offenses 0

## 알려진 검증 제한

`bin/rake quality`는 이번 변경과 무관한 기존 `ArticlesController#show` Flog 102.25가 임계값 93을 초과하여 3/4 게이트만 통과합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 기사 검색 결과와 페이지 정보 조합을 개선했습니다.
  * 검색 결과가 없을 때 관련 검색어 제안을 제공합니다.
  * 검색 결과가 있는 경우 불필요한 제안 조회를 건너뜁니다.
  * 검색어 앞뒤 공백을 자동으로 정리합니다.

* **테스트**
  * 검색 결과, 페이지 이동, 검색어 제안 동작에 대한 검증을 추가했습니다.

* **문서**
  * 기사 검색 처리 흐름과 검증 계획을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->