### PR TITLE
[Test] index_html 테스트 Pagy.new → sentinel 객체 (Pagy 9 호환)

### DIFF
--- a/test/functions/articles/search_test.rb
+++ b/test/functions/articles/search_test.rb
@@ -112,9 +112,11 @@ class Articles::SearchTest < ActiveSupport::TestCase
   end
 
   # ── index_html ──────────────────────────────────────────────────
+  # index_html은 pagy callable을 투명하게 호출해 결과를 그대로 전달만 하므로,
+  # 실제 Pagy 인스턴스(Pagy 9 생성자 호환성 부담) 대신 sentinel 객체로 검증한다.
 
   test "index_html returns an IndexResult with empty suggestions when search is nil" do
-    pagy = Pagy.new(count: 0, page: 1)
+    pagy = Object.new
     result = Articles::Search.index_html(search: nil, pagy: ->(_relation) { [ pagy, [] ] })
 
     assert_instance_of Articles::Search::IndexResult, result
@@ -124,7 +126,7 @@ class Articles::SearchTest < ActiveSupport::TestCase
   end
 
   test "index_html fills suggestions from suggest when articles empty and search present" do
-    pagy = Pagy.new(count: 0, page: 1)
+    pagy = Object.new
     suggest_calls = []
     Articles::Search.stub(:suggest, ->(query, **) {
       suggest_calls << query
@@ -139,7 +141,7 @@ class Articles::SearchTest < ActiveSupport::TestCase
   end
 
   test "index_html skips suggest when articles present" do
-    pagy = Pagy.new(count: 1, page: 1)
+    pagy = Object.new
     article = articles(:ruby_article)
     suggest_calls = []
     Articles::Search.stub(:suggest, ->(*) {


### PR DESCRIPTION
## 문제

PR #872 머지 후 CI/로컬에서 `index_html` 단위 테스트 3개가 실패:

```
Articles::SearchTest#test_index_html_...:
ArgumentError: wrong number of arguments (given 1, expected 0)
  at Pagy.new(count: 0, page: 1)
```

## 원인

Pagy 43.6.0(Pagy 9)에서 `Pagy.new` 생성자 시그니처가 변경되어 `count:`/`page:` 키워드 인자를 받지 못함.

## 해결

`index_html`은 pagy callable을 투명하게 호출해 결과를 그대로 전달만 하므로 실제 Pagy 인스턴스가 불필요. `Pagy.new(count:, page:)` 대신 `Object.new` sentinel 객체로 교체해 Pagy 버전 호환성 부담을 제거. `assert_equal pagy, result.pagy` 동일성 검증은 유지.

## 검증

- `ai:tool[validate]` 통과
- RuboCop no offenses
- textsearch_ko 로컬 빌드 환경 제약으로 실제 실행은 CI/사용자 로컬에 위탁