### PR TITLE
[Test] index_html 테스트 pagy sentinel → Pagy::Offset 실제 인스턴스

### DIFF
--- a/test/functions/articles/search_test.rb
+++ b/test/functions/articles/search_test.rb
@@ -112,11 +112,11 @@ class Articles::SearchTest < ActiveSupport::TestCase
   end
 
   # ── index_html ──────────────────────────────────────────────────
-  # index_html은 pagy callable을 투명하게 호출해 결과를 그대로 전달만 하므로,
-  # 실제 Pagy 인스턴스(Pagy 9 생성자 호환성 부담) 대신 sentinel 객체로 검증한다.
+  # index_html은 pagy callable을 투명하게 호출해 결과를 그대로 전달만 한다.
+  # Pagy 9에서 Pagy는 deprecated shim이므로 실제 paginator인 Pagy::Offset 사용.
 
   test "index_html returns an IndexResult with empty suggestions when search is nil" do
-    pagy = Object.new
+    pagy = Pagy::Offset.new(count: 0, page: 1)
     result = Articles::Search.index_html(search: nil, pagy: ->(_relation) { [ pagy, [] ] })
 
     assert_instance_of Articles::Search::IndexResult, result
@@ -126,7 +126,7 @@ class Articles::SearchTest < ActiveSupport::TestCase
   end
 
   test "index_html fills suggestions from suggest when articles empty and search present" do
-    pagy = Object.new
+    pagy = Pagy::Offset.new(count: 0, page: 1)
     suggest_calls = []
     Articles::Search.stub(:suggest, ->(query, **) {
       suggest_calls << query
@@ -141,7 +141,7 @@ class Articles::SearchTest < ActiveSupport::TestCase
   end
 
   test "index_html skips suggest when articles present" do
-    pagy = Object.new
+    pagy = Pagy::Offset.new(count: 1, page: 1)
     article = articles(:ruby_article)
     suggest_calls = []
     Articles::Search.stub(:suggest, ->(*) {


### PR DESCRIPTION
## 배경

PR #873에서 Pagy 9의 \`Pagy.new\` 생성자 호환 문제로 \`Object.new\` sentinel로 우회.

## 개선

조사 결과 Pagy 9에서 \`Pagy\`는 deprecated shim이고 실제 paginator는 \`Pagy::Offset\`이며 \`Pagy::Offset.new(count:, page:)\`가 정상 동작함을 확인. sentinel 대신 실제 인스턴스로 교체해 테스트 의미를 명확히 함.

## 검증

- \`ai:tool[validate]\` 통과, RuboCop no offenses
- \`Pagy::Offset.new(count: 0, page: 1)\` 런타임 동작 확인(page: 1)
- 로컬 textsearch_ko 빌드 환경 제약으로 실제 테스트 실행은 CI에 위탁