### PR TITLE
Gate sig/generated against inline RBS drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,24 @@ jobs:
       # so install the gem RBSs before checking.
       - name: Install RBS collection
         run: bundle exec rbs collection install
+
+      # Steep reads sig/generated/*.rbs, NOT the `#:` comments those files are
+      # generated from -- so editing an annotation without regenerating leaves
+      # the two silently out of sync and Steep keeps checking the stale copy.
+      # Regenerate and fail if anything moved. Fix with:
+      #   bundle exec rbs-inline --output app lib
+      - name: Check sig/generated is in sync with inline RBS
+        run: |
+          bundle exec rbs-inline --output app lib
+          # --porcelain, not `git diff --exit-code`: a newly annotated file
+          # produces an *untracked* .rbs, which git diff does not report.
+          drift="$(git status --porcelain -- sig/generated)"
+          if [ -n "$drift" ]; then
+            echo "$drift"
+            echo "::error::sig/generated is stale. Run 'bundle exec rbs-inline --output app lib' and commit the result."
+            exit 1
+          fi
+
       - name: Type check with Steep
         run: bundle exec steep check
 

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,13 @@ group :development, :test do
   gem "i18n-tasks", "~> 1.1.2"
   gem "minitest", "~> 6.0"
   gem "minitest-mock"
+  # Generates sig/generated/*.rbs from the inline `#:` comments. Declared
+  # explicitly even though rubocop-rbs_inline pulls it in transitively --
+  # sig/generated is what Steep type-checks, so losing the generator to an
+  # unrelated lint-gem bump would leave those signatures unregenerable.
+  # Upstream plans to fold this into the rbs gem itself and retire rbs-inline;
+  # rbs 4.1.1 has no `inline` subcommand yet, so swap when it does.
+  gem "rbs-inline", require: false
   gem "rubocop", require: false
   gem "rubocop-i18n", require: false
   gem "rubocop-minitest", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1056,6 +1056,7 @@ DEPENDENCIES
   rails-ai-context
   rails-i18n
   rails_semantic_logger
+  rbs-inline
   reactionview (~> 0.3.0)
   resend
   rspec-rails (~> 8.0)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,5 +13,8 @@ pre-commit:
     # stage_fixed는 기존 스테이징 파일의 수정만 다시 스테이징하므로,
     # 신규 .rb에 대해 새로 생성되는 .rbs 파일은 누락된다.
     # 따라서 생성 후 sig/generated 전체를 명시적으로 스테이징한다.
+    # `app lib` must match the CI drift check in .github/workflows/ci.yml --
+    # this hook covered only `app`, which is why lib/search_benchmark.rb never
+    # got a signature despite being tracked and `rbs_inline: enabled`.
     rbs:
-      run: rbs-inline --output app && git add sig/generated
+      run: rbs-inline --output app lib && git add sig/generated

--- a/sig/generated/search_benchmark.rbs
+++ b/sig/generated/search_benchmark.rbs
@@ -1,0 +1,20 @@
+# Generated from lib/search_benchmark.rb with RBS::Inline
+
+module SearchBenchmark
+  # Mean Reciprocal Rank — 평균 역순위.
+  # 여러 쿼리의 ranked_list 와 relevant_ids 쌍에 대해 MRR을 계산한다.
+  # 각 쿼리의 정답은 단일 ID 또는 Array 모두 허용한다. 정답이 여러 개일 때는
+  # 결과에서 가장 먼저 등장하는 정답의 rank 역수를 사용한다(표준 MRR 정의).
+  # : (Array[Array[Integer]] ranked_lists, Array[untyped] relevant_ids_list) -> Float
+  def self?.mrr: (Array[Array[Integer]] ranked_lists, Array[untyped] relevant_ids_list) -> Float
+
+  # Normalized Discounted Cumulative Gain @ k.
+  # Binary relevance: id가 ideal_ranking에 존재하면 relevant=1, 아니면 0.
+  # DCG = Σ (2^rel - 1) / log2(i + 2)  (i=0부터)
+  # : (Array[Array[Integer]] ranked_lists, Array[Array[Integer]] ideal_rankings, ?k: Integer) -> Float
+  def self?.ndcg_at: (Array[Array[Integer]] ranked_lists, Array[Array[Integer]] ideal_rankings, ?k: Integer) -> Float
+
+  # Recall @ k — 전체 relevant 중 상위 k개 내에서 찾은 비율.
+  # : (Array[Array[Integer]] ranked_lists, Array[Array[Integer]] relevant_ids_list, ?k: Integer) -> Float
+  def self?.recall_at: (Array[Array[Integer]] ranked_lists, Array[Array[Integer]] relevant_ids_list, ?k: Integer) -> Float
+end


### PR DESCRIPTION
## 변경 사항

- 인라인 `#:` 주석과 `sig/generated/*.rbs`의 드리프트를 CI에서 차단합니다.
- `rbs-inline`을 Gemfile에 명시적으로 선언했습니다.
- lefthook pre-commit의 `rbs` 명령이 `lib/`을 누락하던 것을 수정했습니다.
- 그로 인해 누락돼 있던 `sig/generated/search_benchmark.rbs`를 커밋합니다.

## 원인

#897 리뷰 중 발견한 구멍입니다.

**Steep이 타입체크하는 대상은 `sig/generated/*.rbs`이지 `#:` 주석이 아닙니다.** 주석은 `rbs-inline`이 그 파일을 만들어내는 원본일 뿐입니다. 확인 차 `app/functions/articles/date_parsing.rb:111`의 주석을 `-> ActiveSupport::TimeWithZone?`에서 `-> Integer?`로 일부러 틀리게 바꿔봤는데, `steep check`는 `--severity-level=hint`까지 내려도 0건이었습니다. 생성 RBS가 옛 값을 그대로 들고 있었기 때문입니다.

즉 주석을 고치고 재생성을 잊으면 둘이 조용히 어긋나고, Steep은 낡은 사본을 계속 검사합니다. #897이 `Steepfile`에 `MethodReturnTypeAnnotationMismatch`를 복원하며 적은 목적("hand-maintained inline return-type annotations are actually validated")은 **누군가 수동으로 재생성했을 때만** 성립하는 상태였습니다.

재생성 태스크(`lib/tasks/rbs.rake`)는 #897에서 삭제됐고, `rbs-inline` 자체도 Gemfile에 없이 `rubocop-rbs_inline`의 전이 의존성으로만 들어오고 있었습니다. 린터 플러그인을 정리하면 Steep의 검사 대상을 재생성할 수단이 조용히 사라지는 구조입니다.

lefthook의 `rbs` 훅은 `rbs-inline --output app`으로 **`lib/`을 훑지 않았습니다.** `lib/search_benchmark.rb`는 추적되는 `rbs_inline: enabled` 파일이고 `Steepfile`이 `check "lib"`를 하는데도 시그니처가 한 번도 생성된 적이 없었습니다(git 이력 없음).

## 영향

- 인라인 주석을 고치고 재생성하지 않으면 CI `typecheck` 잡이 실패합니다. 수정 방법은 에러 메시지에 명시됩니다.
- lefthook 훅과 CI가 같은 명령(`rbs-inline --output app lib`)을 쓰므로, 로컬 통과 / CI 실패가 발생하지 않습니다.
- `lib/` 아래 인라인 주석이 이제 실제로 Steep의 검사를 받습니다.

## 구현 노트

드리프트 판정에 `git diff --exit-code`가 아니라 `git status --porcelain`을 씁니다. **새로 주석이 붙은 파일은 추적되지 않는 `.rbs`를 만들어내고, `git diff`는 그걸 보고하지 않습니다.** 이번에 발견한 `search_benchmark.rbs`가 정확히 그 경우라 `git diff` 방식이었다면 놓쳤을 것입니다.

`rbs-inline`은 upstream이 rbs-gem으로 흡수 후 deprecate할 예정입니다. 다만 현재 `rbs 4.1.1`에는 `inline` 서브커맨드가 없어(`ast, annotate, list, ancestors, methods, method, validate, constant, paths, prototype, vendor, parse, test, collection, subtract, diff, version, help`) 당장은 대안이 없습니다. 병합이 이뤄지면 명령 한 줄만 `rbs inline`으로 갈아끼우면 되고, `git status --porcelain` 판정부는 그대로 씁니다. Gemfile 주석에도 남겼습니다.

## 검증

- 재생성 결과가 기존 161개 파일과 완전 일치 (신규 `search_benchmark.rbs` 1개 외 변화 없음)
- `bundle exec steep check`: 통과 (신규 시그니처 포함)
- `bundle exec srb tc`: `No errors!`
- **드리프트 음성 테스트**: `app/models/preference.rb`의 `#: () -> Array[String]`을 `Array[Symbol]`로 주입 → `M sig/generated/models/preference.rbs` 검출, 복원 시 해소
- CI YAML 파싱 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
  - 타입 검사 단계에서 인라인 RBS 주석과 생성된 선언 파일의 동기화 상태를 자동으로 검증합니다.
  - 불일치하거나 누락된 선언 파일이 있으면 CI 작업이 실패하도록 개선했습니다.

- **개선 사항**
  - 커밋 전 RBS 생성 대상에 `lib` 디렉터리를 포함했습니다.
  - RBS 선언 생성을 위한 개발 의존성을 추가하고 관련 동작을 명확히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->