### PR TITLE
Add Steep rake tasks for daemon and regeneration

### DIFF
--- a/lib/tasks/steep.rake
+++ b/lib/tasks/steep.rake
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+# rbs_inline: disabled
+
+# Steep type-checking entry points.
+#
+# Steep 2.0 additions in use here:
+#   * `steep server` -- daemon that keeps the RBS environment loaded in memory,
+#     so repeated `steep check` runs skip the slow environment reload. Useful
+#     while bumping files from `# typed: false` to `# typed: true`, which is
+#     many iterative checks.
+#   * `steep check -e "EXPR"` -- type-check a one-liner from the CLI without
+#     editing files, e.g. `bundle exec steep check -e "Like.for_actor(nil)"`.
+#
+# Pipeline (see .github/workflows/ci.yml): Steep reads `sig/generated/*.rbs`
+# produced by `rbs-inline`, NOT the inline `#:` comments those files are
+# generated from. After editing a `#:` annotation, run `rake steep:regenerate`
+# and commit the changed `sig/generated/` so the two stay in sync -- CI rejects
+# drift between them.
+#
+# `inline: true` is intentionally NOT enabled. Native inline RBS in Steep 2.0
+# is experimental, omits `class << self`, and does not yet reproduce the broad
+# body type-checking the generated signatures provide; enabling it alongside
+# the pipeline yields ~100 DuplicatedDeclaration errors from the duplicate
+# declarations. Keep the rbs-inline generation until native inline matures and
+# the `class << self` (and similar) gaps are filled.
+
+namespace :steep do
+  desc "Type-check with Steep (faster if `steep:server:start` is running)"
+  task :check do
+    sh "bundle exec steep check"
+  end
+
+  desc "Regenerate sig/generated from inline `#:` annotations (run after editing them)"
+  task :regenerate do
+    sh "bundle exec rbs-inline --output app lib"
+  end
+
+  namespace :server do
+    desc "Start the Steep daemon (keeps RBS env in memory for faster checks)"
+    task :start do
+      sh "bundle exec steep server start"
+    end
+
+    desc "Stop the Steep daemon"
+    task :stop do
+      sh "bundle exec steep server stop"
+    end
+
+    desc "Restart the Steep daemon (after Steepfile or RBS changes)"
+    task :restart do
+      sh "bundle exec steep server restart"
+    end
+
+    desc "Show Steep daemon status"
+    task :status do
+      sh "bundle exec steep server status"
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `lib/tasks/steep.rake` — rake entry points for the Steep 2.0 type checker. No runtime or app-code changes.

## Tasks

| task | action |
|------|--------|
| `rake steep:check` | `bundle exec steep check` (matches CI; uses the daemon if running) |
| `rake steep:regenerate` | `bundle exec rbs-inline --output app lib` (sync `sig/generated` with inline `#:` annotations) |
| `rake steep:server:start` / `:stop` / `:restart` / `:status` | Steep 2.0 daemon management |

## Why

The Steep 2.0 daemon keeps the RBS environment loaded in memory, so repeated `steep check` runs skip the slow environment reload. This is the main accelerant for the next planned work — bumping files from `# typed: false` to `# typed: true`, which is many iterative checks.

The file header also documents:
- `steep check -e "EXPR"` — type-check a one-liner from the CLI without editing files.
- Why `inline: true` stays **off**: native inline RBS in Steep 2.0 is experimental, omits `class << self`, and does not reproduce the broad body type-checking the generated signatures provide. Enabling it alongside the existing pipeline yields ~100 `DuplicatedDeclaration` errors (inline annotations and `sig/generated` redeclare the same constants/classes). The rbs-inline generation pipeline stays in place until native inline matures.

## Verification

- `bundle exec rake steep:check` → `No type error detected` (matches CI)
- Daemon lifecycle via rake: start → status → check → stop, all clean
- `bundle exec rubocop lib/tasks/steep.rake` → no offenses
- lefthook pre-commit (rbs-inline + rubocop) → pass
- `git status`: only `lib/tasks/steep.rake` added (Steepfile, `sig/generated`, source files untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Steep 타입 검사를 실행하는 Rake 작업을 추가했습니다.
  * 인라인 RBS 파일을 재생성하는 작업을 추가했습니다.
  * Steep 서버의 시작, 중지, 재시작 및 상태 확인 작업을 지원합니다.

* **문서**
  * Steep 2.0 사용 방법과 RBS 생성 파일 동기화 절차를 안내하는 설명을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->