### PR TITLE
chore(steep): 0건 진단 33종을 strict 심각도로 래칫

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -6,6 +6,88 @@ D = Steep::Diagnostic
 # Run `rbs collection install` to install the RBS files.
 # Steep will automatically pick up the RBS files from the collection.
 
+# --- Diagnostic scope ------------------------------------------------------
+#
+# Generated Rails/DSL signatures are intentionally incomplete, so most app code
+# lacks types and would fail wholesale under `default`. The base stays
+# `lenient`, and the scope is widened one diagnostic at a time.
+#
+# `CLEAN_DIAGNOSTICS` below are the diagnostics the codebase currently has
+# *zero* occurrences of, measured by running `steep check` with
+# `D::Ruby.all_error` on both targets (2026-08-04: 12,574 problems total, none
+# from these). Raising them to their `strict` severity therefore costs nothing
+# today and acts as a ratchet: the first new violation fails CI instead of
+# quietly joining the debt pile.
+#
+# Steep gates on severity >= :warning, so :hint/:information entries here are
+# informational only.
+#
+# To widen further, promote the next-cheapest diagnostic from the remaining
+# debt (occurrence counts as of 2026-08-04):
+#
+#     ClassModuleMismatch 1, InsufficientKeywordArguments 1, UnexpectedYield 1,
+#     UnexpectedBlockGiven 2, UnreachableValueBranch 2, BlockBodyTypeMismatch 4,
+#     BlockTypeMismatch 5, RequiredBlockMissing 7, UnknownRecordKey 7,
+#     UnexpectedPositionalArgument 13, UnexpectedSuper 13, UnsupportedSyntax 15,
+#     IncompatibleAssignment 17, UnexpectedKeywordArgument 17,
+#     UnreachableBranch 30, MethodDefinitionMissing 33, ArgumentTypeMismatch 43,
+#     UndeclaredMethodDefinition 44, UnresolvedOverloading 93,
+#     UnannotatedEmptyCollection 225
+#
+# The remaining five are the signature-coverage wall, not fixable one call site
+# at a time -- they need real Phlex/Rails RBS rather than annotations:
+#
+#     UnknownInstanceVariable 469, MethodDefinitionInUndeclaredModule 677,
+#     UnknownConstant 1229, FallbackAny 1899, NoMethod 7727
+#
+# Re-measure with:
+#     bundle exec steep check --steepfile=<file using D::Ruby.all_error>
+CLEAN_DIAGNOSTICS = [
+  D::Ruby::AnnotationSyntaxError,
+  D::Ruby::BreakTypeMismatch,
+  D::Ruby::DeprecatedReference,
+  D::Ruby::DifferentMethodParameterKind,
+  D::Ruby::FalseAssertion,
+  D::Ruby::ImplicitBreakValueMismatch,
+  D::Ruby::IncompatibleAnnotation,
+  D::Ruby::IncompatibleArgumentForwarding,
+  D::Ruby::InsufficientPositionalArguments,
+  D::Ruby::InsufficientTypeArgument,
+  D::Ruby::InvalidIgnoreComment,
+  D::Ruby::LibraryRBSError,
+  D::Ruby::MethodArityMismatch,
+  D::Ruby::MethodBodyTypeMismatch,
+  D::Ruby::MethodParameterMismatch,
+  D::Ruby::MethodReturnTypeAnnotationMismatch,
+  D::Ruby::MultipleAssignmentConversionError,
+  D::Ruby::ProcHintIgnored,
+  D::Ruby::ProcTypeExpected,
+  D::Ruby::RBSError,
+  D::Ruby::RedundantIgnoreComment,
+  D::Ruby::ReturnTypeMismatch,
+  D::Ruby::SetterBodyTypeMismatch,
+  D::Ruby::SetterReturnTypeMismatch,
+  D::Ruby::SyntaxError,
+  D::Ruby::TypeArgumentMismatchError,
+  D::Ruby::UnexpectedDynamicMethod,
+  D::Ruby::UnexpectedError,
+  D::Ruby::UnexpectedJump,
+  D::Ruby::UnexpectedJumpValue,
+  D::Ruby::UnexpectedTypeArgument,
+  D::Ruby::UnknownGlobalVariable,
+  D::Ruby::UnsatisfiableConstraint,
+].freeze
+
+# Lenient base + strict severity for everything we are already clean on.
+# A lambda rather than a method: the Steepfile is `instance_eval`ed, and a `def`
+# here would land on the outer DSL object and be invisible inside `target`.
+RATCHETED_DIAGNOSTICS = lambda do
+  strict = D::Ruby.strict
+  D::Ruby.lenient.dup.tap do |diagnostics|
+    CLEAN_DIAGNOSTICS.each { |key| diagnostics[key] = strict.fetch(key) }
+  end
+end
+
 # Default target for the main application code
 target :app do
   # Where to find application-specific RBS files
@@ -18,14 +100,7 @@ target :app do
   ignore "lib/tasks/**/*.rake"
   ignore "lib/protobuf/**/*"
 
-  # Generated Rails/DSL signatures are intentionally incomplete, so most app
-  # code lacks types and would fail under the default severity. Use the lenient
-  # base for that existing debt, but restore MethodReturnTypeAnnotationMismatch
-  # (which `lenient` disables) so the hand-maintained inline return-type
-  # annotations are actually validated instead of silently skipped.
-  diagnostics = D::Ruby.lenient.dup
-  diagnostics[D::Ruby::MethodReturnTypeAnnotationMismatch] = :hint
-  configure_code_diagnostics(diagnostics)
+  configure_code_diagnostics(RATCHETED_DIAGNOSTICS.call)
 end
 
 # Target for the test suite
@@ -36,9 +111,6 @@ target :test do
   # Directory to type check
   check "test"
 
-  # Same lenient base as :app so test type gaps don't gate the build, while
-  # still validating inline return-type annotations.
-  test_diagnostics = D::Ruby.lenient.dup
-  test_diagnostics[D::Ruby::MethodReturnTypeAnnotationMismatch] = :hint
-  configure_code_diagnostics(test_diagnostics)
+  # Same ratchet as :app -- the zero-occurrence measurement covered both targets.
+  configure_code_diagnostics(RATCHETED_DIAGNOSTICS.call)
 end


### PR DESCRIPTION
## 배경

Steep은 `lenient` 프리셋으로 CI에 들어와 있고 현재 0에러다. 검사 범위를 넓히려면 남은 부채가 어떤 모양인지부터 알아야 해서 `D::Ruby.all_error`로 전량 측정했다.

**12,574건 / 454파일.** 분포가 극단적으로 치우쳐 있다.

| 구간 | 진단 | 건수 |
|---|---|---|
| A. 시그니처 커버리지 벽 | NoMethod 7727, FallbackAny 1899, UnknownConstant 1229, MethodDefinitionInUndeclaredModule 677, UnknownInstanceVariable 469 | **12,001 (95%)** |
| B. 호출부 단위로 고칠 수 있는 것 | UnannotatedEmptyCollection 225, UnresolvedOverloading 93, UndeclaredMethodDefinition 44, ArgumentTypeMismatch 43 … 20종 | **573** |
| C. 이미 0건 | 33종 | **0** |

A는 Phlex DSL·Rails 헬퍼 RBS가 없어서 나는 노이즈다. 호출부를 고쳐도 줄지 않고, 진짜 Phlex/Rails 시그니처가 필요하다. 넓힐 여지는 B와 C에 있다.

## 이 PR이 하는 일 — C구간

0건인 33종을 `lenient` → 각 진단의 `strict` 심각도로 올린다. 오늘 비용 0, 대신 **새 위반이 처음 생기는 순간 CI가 막는 래칫**이 된다. 나머지는 `lenient` 유지.

실질적으로 새로 게이트가 걸리는 것:

- `MethodArityMismatch` / `MethodParameterMismatch` / `InsufficientPositionalArguments` / `IncompatibleArgumentForwarding` — 인자 개수·종류 불일치
- `SetterBodyTypeMismatch` / `SetterReturnTypeMismatch` / `ProcTypeExpected` / `MultipleAssignmentConversionError` — lenient에서 아예 `off`였던 것
- `RBSError`, `MethodReturnTypeAnnotationMismatch`

### 기존 주석이 사실과 달랐던 부분

Steepfile에는 "`lenient`가 끄는 `MethodReturnTypeAnnotationMismatch`를 되살려 인라인 반환 타입 주석이 실제로 검증되게 한다"고 적혀 있었지만, 설정값이 `:hint`라 **CI를 막지 못했다**. Steep은 심각도 `:warning` 이상에서만 exit 1이다 — `UnannotatedEmptyCollection`만 `:warning`으로 두고 돌려 141건에 exit=1인 것으로 실측 확인했다. 이제 `:error`다.

### 구현 노트

Steepfile은 `instance_eval`되므로 헬퍼를 `def`로 두면 바깥 DSL 객체에 정의되어 `target` 블록 안에서 `NameError`가 난다. lambda로 뒀다.

## 검증

- `bundle exec steep check` → `No type error detected` (양쪽 target)
- `bundle exec rbs -I sig validate` → 통과
- `rbs-inline` 재생성 후 `sig/generated` 드리프트 없음
- **래칫 동작 확인**: 임시 probe 파일에 시그니처(`() -> Integer`)와 `def`의 인자를 어긋나게 만들어 `Ruby::MethodParameterMismatch` 에러가 실제로 잡히는 것을 확인한 뒤 제거

## 다음 회차

다음 승급 후보의 건수와 재측정 명령을 Steepfile 주석에 기록해뒀다. 가장 싼 것부터: `ClassModuleMismatch` 1, `InsufficientKeywordArguments` 1, `UnexpectedYield` 1 … `UnexpectedKeywordArgument` 17. 20건 미만 14종을 합쳐도 ~105건이고, 대부분 인자 불일치·블록 누락이라 진짜 버그 후보다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUPLdoAC2L4qYJBkwrotaj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 정적 타입 진단 범위가 확대되었습니다.
  * 오류가 없는 진단 항목에는 더 엄격한 기준이 적용되어 잠재적인 문제를 조기에 확인할 수 있습니다.
  * 진단 결과의 일관성과 신뢰성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->