### PR TITLE
chore(sorbet): 481개 파일에 시길 부여, 296개를 typed: true로 상향

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,14 @@ jobs:
       # Static only -- no database or credentials needed. The RBI files under
       # sorbet/rbi are committed, so this never regenerates them; if they drift
       # from Gemfile.lock, run `bundle exec tapioca gem` and commit the result.
-      # All app/lib files declare `# typed: false` (or omit the sigil, which
-      # defaults to false), so this gate currently catches syntax errors,
-      # RBI/sigil drift, and autoload/require issues -- not type errors. Bump
-      # files to `# typed: true` incrementally to start enforcing signatures.
+      # Every file under app/lib/test now carries an explicit sigil: 296 at
+      # `# typed: true` (where Sorbet enforces signatures and constant/method
+      # resolution) and 185 still at `# typed: false` (syntax and RBI drift
+      # only). Widen by re-running `bundle exec spoom srb bump . --dry`, which
+      # lists the files that would type check cleanly at the next level up.
+      #
+      # A NEW file with no sigil defaults to `false` and is therefore invisible
+      # to this gate -- add one when creating files.
       - name: Type check with Sorbet
         run: bundle exec srb tc
 

--- a/Steepfile
+++ b/Steepfile
@@ -100,7 +100,7 @@ CLEAN_DIAGNOSTICS = [
   D::Ruby::InsufficientKeywordArguments,
   D::Ruby::UnexpectedBlockGiven,
   D::Ruby::UnexpectedYield,
-  D::Ruby::UnknownRecordKey,
+  D::Ruby::UnknownRecordKey
 ].freeze
 
 # Lenient base + strict severity for everything we are already clean on.

--- a/Steepfile
+++ b/Steepfile
@@ -12,30 +12,47 @@ D = Steep::Diagnostic
 # lacks types and would fail wholesale under `default`. The base stays
 # `lenient`, and the scope is widened one diagnostic at a time.
 #
-# `CLEAN_DIAGNOSTICS` below are the diagnostics the codebase currently has
-# *zero* occurrences of, measured by running `steep check` with
-# `D::Ruby.all_error` on both targets (2026-08-04: 12,574 problems total, none
-# from these). Raising them to their `strict` severity therefore costs nothing
+# `CLEAN_DIAGNOSTICS` below are the diagnostics the codebase has *zero*
+# occurrences of, measured by running `steep check` with `D::Ruby.all_error` on
+# both targets. Raising them to their `strict` severity therefore costs nothing
 # today and acts as a ratchet: the first new violation fails CI instead of
 # quietly joining the debt pile.
+#
+# The list grows as debt is paid off. The last six entries -- ClassModuleMismatch
+# through UnknownRecordKey -- were driven to zero rather than found at zero.
 #
 # Steep gates on severity >= :warning, so :hint/:information entries here are
 # informational only.
 #
-# To widen further, promote the next-cheapest diagnostic from the remaining
-# debt (occurrence counts as of 2026-08-04):
+# Remaining debt, with why each is still `lenient` (counts as of 2026-08-04).
+# These were each investigated; none can currently be driven to zero:
 #
-#     ClassModuleMismatch 1, InsufficientKeywordArguments 1, UnexpectedYield 1,
-#     UnexpectedBlockGiven 2, UnreachableValueBranch 2, BlockBodyTypeMismatch 4,
-#     BlockTypeMismatch 5, RequiredBlockMissing 7, UnknownRecordKey 7,
-#     UnexpectedPositionalArgument 13, UnexpectedSuper 13, UnsupportedSyntax 15,
-#     IncompatibleAssignment 17, UnexpectedKeywordArgument 17,
-#     UnreachableBranch 30, MethodDefinitionMissing 33, ArgumentTypeMismatch 43,
-#     UndeclaredMethodDefinition 44, UnresolvedOverloading 93,
-#     UnannotatedEmptyCollection 225
+#   UnreachableValueBranch 2       Steep proves an `else` unreachable. Only
+#                                  "fixable" by deleting defensive branches.
+#   BlockBodyTypeMismatch 4        `to_h { [k, v] }` -- Steep wants
+#                                  `Hash::_Pair`, gets `Array[untyped]`.
+#   BlockTypeMismatch 5            `&:sym` and `&` forwarding typed as bare
+#                                  `::Proc` instead of a proc type.
+#   RequiredBlockMissing 7         Anonymous block forwarding (`foo(&)`) plus
+#                                  gem RBS that omits block forms.
+#   UnexpectedSuper 9              Needs ActiveRecord schema signatures: two
+#                                  are `super` from an attribute-writer
+#                                  override (`Article#title=`,
+#                                  `Preference#name=`) whose target only
+#                                  exists once columns are typed. The other
+#                                  seven are Devise/Madmin/ActionMailer RBS
+#                                  declaring the controllers but not the
+#                                  methods we override.
+#   UnexpectedPositionalArgument 13
+#   UnexpectedKeywordArgument 17   Gem RBS argument lists narrower than the
+#                                  real methods. Fixable one `| ...` overload
+#                                  at a time, but ~30 separate gem gaps.
+#   UnsupportedSyntax 15           NOT fixable here -- Steep 2.0 does not
+#                                  support splat-into-untyped (`dig(*path)`,
+#                                  `includes(*CONST)`) or `case/in`.
 #
-# The remaining five are the signature-coverage wall, not fixable one call site
-# at a time -- they need real Phlex/Rails RBS rather than annotations:
+# Beyond those, five diagnostics are the signature-coverage wall. They are not
+# fixable one call site at a time -- they need real Phlex/Rails RBS:
 #
 #     UnknownInstanceVariable 469, MethodDefinitionInUndeclaredModule 677,
 #     UnknownConstant 1229, FallbackAny 1899, NoMethod 7727
@@ -76,6 +93,14 @@ CLEAN_DIAGNOSTICS = [
   D::Ruby::UnexpectedTypeArgument,
   D::Ruby::UnknownGlobalVariable,
   D::Ruby::UnsatisfiableConstraint,
+
+  # Driven to zero, not found at zero -- see the PR that added this block.
+  D::Ruby::ClassModuleMismatch,
+  D::Ruby::IncompatibleAssignment,
+  D::Ruby::InsufficientKeywordArguments,
+  D::Ruby::UnexpectedBlockGiven,
+  D::Ruby::UnexpectedYield,
+  D::Ruby::UnknownRecordKey,
 ].freeze
 
 # Lenient base + strict severity for everything we are already clean on.

--- a/app/agents/article_agent.rb
+++ b/app/agents/article_agent.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/agents/article_image_agent.rb
+++ b/app/agents/article_image_agent.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/agents/article_japanese_agent.rb
+++ b/app/agents/article_japanese_agent.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/agents/article_japanese_schema.rb
+++ b/app/agents/article_japanese_schema.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/agents/article_schema.rb
+++ b/app/agents/article_schema.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/agents/human_monolith_agent.rb
+++ b/app/agents/human_monolith_agent.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/clients/hacker_news.rb
+++ b/app/clients/hacker_news.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/clients/http_timeouts.rb
+++ b/app/clients/http_timeouts.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/clients/mastodon_client.rb
+++ b/app/clients/mastodon_client.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/clients/twitter_client.rb
+++ b/app/clients/twitter_client.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/components/articles/article.rb
+++ b/app/components/articles/article.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::Articles::Article < Components::Base

--- a/app/components/articles/article_user.rb
+++ b/app/components/articles/article_user.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Articles::ArticleUser < Components::Base

--- a/app/components/articles/form.rb
+++ b/app/components/articles/form.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Articles::Form < Components::Base

--- a/app/components/articles/google_search.rb
+++ b/app/components/articles/google_search.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Articles::GoogleSearch < Components::Base

--- a/app/components/articles/search_suggestion.rb
+++ b/app/components/articles/search_suggestion.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/components/articles/search_tabs.rb
+++ b/app/components/articles/search_tabs.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Articles::SearchTabs < Components::Base

--- a/app/components/base.rb
+++ b/app/components/base.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Base < Phlex::HTML

--- a/app/components/boosts/button.rb
+++ b/app/components/boosts/button.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::Boosts::Button < Components::Base

--- a/app/components/comments/comment.rb
+++ b/app/components/comments/comment.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::Comments::Comment < Components::Base

--- a/app/components/comments/comment_form.rb
+++ b/app/components/comments/comment_form.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::Comments::CommentForm < Components::Base

--- a/app/components/comments/comment_header.rb
+++ b/app/components/comments/comment_header.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::Comments::CommentHeader < Components::Base

--- a/app/components/comments/comment_reply_form.rb
+++ b/app/components/comments/comment_reply_form.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::Comments::CommentReplyForm < Components::Base

--- a/app/components/comments/comments.rb
+++ b/app/components/comments/comments.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Comments::Comments < Components::Base

--- a/app/components/flash.rb
+++ b/app/components/flash.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Flash < Components::Base

--- a/app/components/home/article.rb
+++ b/app/components/home/article.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::Home::Article < Components::Base

--- a/app/components/home/feature.rb
+++ b/app/components/home/feature.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::Home::Feature < Components::Base

--- a/app/components/layout.rb
+++ b/app/components/layout.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Layout < Components::Base

--- a/app/components/layout/asset_preloads.rb
+++ b/app/components/layout/asset_preloads.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/components/layout/footer.rb
+++ b/app/components/layout/footer.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::Layout::Footer < Components::Base

--- a/app/components/layout/meta_tags.rb
+++ b/app/components/layout/meta_tags.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Layout::MetaTags < Components::Base

--- a/app/components/layout/nav_bar.rb
+++ b/app/components/layout/nav_bar.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::Layout::NavBar < Components::Base

--- a/app/components/layout/structured_data.rb
+++ b/app/components/layout/structured_data.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Layout::StructuredData < Components::Base

--- a/app/components/likes/button.rb
+++ b/app/components/likes/button.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::Likes::Button < Components::Base

--- a/app/components/login_required.rb
+++ b/app/components/login_required.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::LoginRequired < Components::Base

--- a/app/components/mailers/layout.rb
+++ b/app/components/mailers/layout.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Mailers::Layout < Components::Base

--- a/app/components/oauth_button/apple.rb
+++ b/app/components/oauth_button/apple.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::OauthButton::Apple < Components::Base

--- a/app/components/oauth_button/github.rb
+++ b/app/components/oauth_button/github.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::OauthButton::Github < Components::Base

--- a/app/components/oauth_button/google.rb
+++ b/app/components/oauth_button/google.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::OauthButton::Google < Components::Base

--- a/app/components/pagination.rb
+++ b/app/components/pagination.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::Pagination < Components::Base

--- a/app/components/posts/blog_editor.rb
+++ b/app/components/posts/blog_editor.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Posts::BlogEditor < Components::Base

--- a/app/components/posts/post_card.rb
+++ b/app/components/posts/post_card.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::Posts::PostCard < Components::Base

--- a/app/components/posts/post_form.rb
+++ b/app/components/posts/post_form.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Posts::PostForm < Components::Base

--- a/app/components/posts/post_thread.rb
+++ b/app/components/posts/post_thread.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Posts::PostThread < Components::Base

--- a/app/components/posts/reply_form.rb
+++ b/app/components/posts/reply_form.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Posts::ReplyForm < Components::Base

--- a/app/components/profiles/activity_tabs.rb
+++ b/app/components/profiles/activity_tabs.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Profiles::ActivityTabs < Components::Base

--- a/app/components/push_notifications/prompt_modal.rb
+++ b/app/components/push_notifications/prompt_modal.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::PushNotifications::PromptModal < Components::Base

--- a/app/components/recent_comments_sidebar.rb
+++ b/app/components/recent_comments_sidebar.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::RecentCommentsSidebar < Components::Base

--- a/app/components/ruby_ui/alert/alert.rb
+++ b/app/components/ruby_ui/alert/alert.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/alert/alert_description.rb
+++ b/app/components/ruby_ui/alert/alert_description.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/alert/alert_title.rb
+++ b/app/components/ruby_ui/alert/alert_title.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/alert_dialog/alert_dialog.rb
+++ b/app/components/ruby_ui/alert_dialog/alert_dialog.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/alert_dialog/alert_dialog_action.rb
+++ b/app/components/ruby_ui/alert_dialog/alert_dialog_action.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/alert_dialog/alert_dialog_cancel.rb
+++ b/app/components/ruby_ui/alert_dialog/alert_dialog_cancel.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/alert_dialog/alert_dialog_content.rb
+++ b/app/components/ruby_ui/alert_dialog/alert_dialog_content.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/alert_dialog/alert_dialog_description.rb
+++ b/app/components/ruby_ui/alert_dialog/alert_dialog_description.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/alert_dialog/alert_dialog_footer.rb
+++ b/app/components/ruby_ui/alert_dialog/alert_dialog_footer.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/alert_dialog/alert_dialog_header.rb
+++ b/app/components/ruby_ui/alert_dialog/alert_dialog_header.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/alert_dialog/alert_dialog_title.rb
+++ b/app/components/ruby_ui/alert_dialog/alert_dialog_title.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/alert_dialog/alert_dialog_trigger.rb
+++ b/app/components/ruby_ui/alert_dialog/alert_dialog_trigger.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/avatar/avatar.rb
+++ b/app/components/ruby_ui/avatar/avatar.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/avatar/avatar_fallback.rb
+++ b/app/components/ruby_ui/avatar/avatar_fallback.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/avatar/avatar_image.rb
+++ b/app/components/ruby_ui/avatar/avatar_image.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/badge/badge.rb
+++ b/app/components/ruby_ui/badge/badge.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/base.rb
+++ b/app/components/ruby_ui/base.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "tailwind_merge"

--- a/app/components/ruby_ui/breadcrumb/breadcrumb.rb
+++ b/app/components/ruby_ui/breadcrumb/breadcrumb.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/breadcrumb/breadcrumb_ellipsis.rb
+++ b/app/components/ruby_ui/breadcrumb/breadcrumb_ellipsis.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/breadcrumb/breadcrumb_item.rb
+++ b/app/components/ruby_ui/breadcrumb/breadcrumb_item.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/breadcrumb/breadcrumb_link.rb
+++ b/app/components/ruby_ui/breadcrumb/breadcrumb_link.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/breadcrumb/breadcrumb_list.rb
+++ b/app/components/ruby_ui/breadcrumb/breadcrumb_list.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/breadcrumb/breadcrumb_page.rb
+++ b/app/components/ruby_ui/breadcrumb/breadcrumb_page.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/breadcrumb/breadcrumb_separator.rb
+++ b/app/components/ruby_ui/breadcrumb/breadcrumb_separator.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/button/button.rb
+++ b/app/components/ruby_ui/button/button.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/card/card.rb
+++ b/app/components/ruby_ui/card/card.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/card/card_content.rb
+++ b/app/components/ruby_ui/card/card_content.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/card/card_description.rb
+++ b/app/components/ruby_ui/card/card_description.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/card/card_footer.rb
+++ b/app/components/ruby_ui/card/card_footer.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/card/card_header.rb
+++ b/app/components/ruby_ui/card/card_header.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/card/card_title.rb
+++ b/app/components/ruby_ui/card/card_title.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/carousel/carousel.rb
+++ b/app/components/ruby_ui/carousel/carousel.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/carousel/carousel_content.rb
+++ b/app/components/ruby_ui/carousel/carousel_content.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/carousel/carousel_item.rb
+++ b/app/components/ruby_ui/carousel/carousel_item.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/carousel/carousel_next.rb
+++ b/app/components/ruby_ui/carousel/carousel_next.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/carousel/carousel_previous.rb
+++ b/app/components/ruby_ui/carousel/carousel_previous.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/chart/chart.rb
+++ b/app/components/ruby_ui/chart/chart.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/checkbox/checkbox.rb
+++ b/app/components/ruby_ui/checkbox/checkbox.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/checkbox/checkbox_group.rb
+++ b/app/components/ruby_ui/checkbox/checkbox_group.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/dialog/dialog.rb
+++ b/app/components/ruby_ui/dialog/dialog.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/dialog/dialog_content.rb
+++ b/app/components/ruby_ui/dialog/dialog_content.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/dialog/dialog_description.rb
+++ b/app/components/ruby_ui/dialog/dialog_description.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/dialog/dialog_footer.rb
+++ b/app/components/ruby_ui/dialog/dialog_footer.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/dialog/dialog_header.rb
+++ b/app/components/ruby_ui/dialog/dialog_header.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/dialog/dialog_middle.rb
+++ b/app/components/ruby_ui/dialog/dialog_middle.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/dialog/dialog_title.rb
+++ b/app/components/ruby_ui/dialog/dialog_title.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/dialog/dialog_trigger.rb
+++ b/app/components/ruby_ui/dialog/dialog_trigger.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/dropdown_menu/dropdown_menu.rb
+++ b/app/components/ruby_ui/dropdown_menu/dropdown_menu.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/dropdown_menu/dropdown_menu_content.rb
+++ b/app/components/ruby_ui/dropdown_menu/dropdown_menu_content.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/dropdown_menu/dropdown_menu_item.rb
+++ b/app/components/ruby_ui/dropdown_menu/dropdown_menu_item.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/dropdown_menu/dropdown_menu_label.rb
+++ b/app/components/ruby_ui/dropdown_menu/dropdown_menu_label.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/dropdown_menu/dropdown_menu_separator.rb
+++ b/app/components/ruby_ui/dropdown_menu/dropdown_menu_separator.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/dropdown_menu/dropdown_menu_trigger.rb
+++ b/app/components/ruby_ui/dropdown_menu/dropdown_menu_trigger.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/form/form.rb
+++ b/app/components/ruby_ui/form/form.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/form/form_field.rb
+++ b/app/components/ruby_ui/form/form_field.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/form/form_field_error.rb
+++ b/app/components/ruby_ui/form/form_field_error.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/form/form_field_hint.rb
+++ b/app/components/ruby_ui/form/form_field_hint.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/form/form_field_label.rb
+++ b/app/components/ruby_ui/form/form_field_label.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/input/input.rb
+++ b/app/components/ruby_ui/input/input.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/link/link.rb
+++ b/app/components/ruby_ui/link/link.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/pagination/pagination.rb
+++ b/app/components/ruby_ui/pagination/pagination.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/pagination/pagination_content.rb
+++ b/app/components/ruby_ui/pagination/pagination_content.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/pagination/pagination_ellipsis.rb
+++ b/app/components/ruby_ui/pagination/pagination_ellipsis.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/pagination/pagination_item.rb
+++ b/app/components/ruby_ui/pagination/pagination_item.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/popover/popover.rb
+++ b/app/components/ruby_ui/popover/popover.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/popover/popover_content.rb
+++ b/app/components/ruby_ui/popover/popover_content.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/popover/popover_trigger.rb
+++ b/app/components/ruby_ui/popover/popover_trigger.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/progress/progress.rb
+++ b/app/components/ruby_ui/progress/progress.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/radio_button/radio_button.rb
+++ b/app/components/ruby_ui/radio_button/radio_button.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/select/select.rb
+++ b/app/components/ruby_ui/select/select.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/select/select_content.rb
+++ b/app/components/ruby_ui/select/select_content.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/select/select_group.rb
+++ b/app/components/ruby_ui/select/select_group.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/select/select_input.rb
+++ b/app/components/ruby_ui/select/select_input.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/select/select_item.rb
+++ b/app/components/ruby_ui/select/select_item.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/select/select_label.rb
+++ b/app/components/ruby_ui/select/select_label.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/select/select_trigger.rb
+++ b/app/components/ruby_ui/select/select_trigger.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/select/select_value.rb
+++ b/app/components/ruby_ui/select/select_value.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/separator/separator.rb
+++ b/app/components/ruby_ui/separator/separator.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/switch/switch.rb
+++ b/app/components/ruby_ui/switch/switch.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/tabs/tabs.rb
+++ b/app/components/ruby_ui/tabs/tabs.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/tabs/tabs_content.rb
+++ b/app/components/ruby_ui/tabs/tabs_content.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/tabs/tabs_list.rb
+++ b/app/components/ruby_ui/tabs/tabs_list.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/tabs/tabs_trigger.rb
+++ b/app/components/ruby_ui/tabs/tabs_trigger.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/textarea/textarea.rb
+++ b/app/components/ruby_ui/textarea/textarea.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/theme_toggle/set_dark_mode.rb
+++ b/app/components/ruby_ui/theme_toggle/set_dark_mode.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/theme_toggle/set_light_mode.rb
+++ b/app/components/ruby_ui/theme_toggle/set_light_mode.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/theme_toggle/theme_toggle.rb
+++ b/app/components/ruby_ui/theme_toggle/theme_toggle.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/typography/heading.rb
+++ b/app/components/ruby_ui/typography/heading.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/typography/inline_code.rb
+++ b/app/components/ruby_ui/typography/inline_code.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/typography/inline_link.rb
+++ b/app/components/ruby_ui/typography/inline_link.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/typography/text.rb
+++ b/app/components/ruby_ui/typography/text.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/ruby_ui/typography/typography_blockquote.rb
+++ b/app/components/ruby_ui/typography/typography_blockquote.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 module RubyUI

--- a/app/components/tags_sidebar.rb
+++ b/app/components/tags_sidebar.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::TagsSidebar < Components::Base

--- a/app/components/user_avatar.rb
+++ b/app/components/user_avatar.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::UserAvatar < Components::Base

--- a/app/components/users/form.rb
+++ b/app/components/users/form.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Users::Form < Components::Base

--- a/app/components/users/form/actions.rb
+++ b/app/components/users/form/actions.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::Users::Form::Actions < Components::Base

--- a/app/components/users/form/error_messages.rb
+++ b/app/components/users/form/error_messages.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::Users::Form::ErrorMessages < Components::Base

--- a/app/components/users/form/header.rb
+++ b/app/components/users/form/header.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Users::Form::Header < Components::Base

--- a/app/components/users/form/input_styling.rb
+++ b/app/components/users/form/input_styling.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 # users/form 필드 서브컴포넌트들이 공유하는 입력 필드 클래스 헬퍼.

--- a/app/components/users/form/new_fields.rb
+++ b/app/components/users/form/new_fields.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Users::Form::NewFields < Components::Base

--- a/app/components/users/form/password_fields.rb
+++ b/app/components/users/form/password_fields.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Users::Form::PasswordFields < Components::Base

--- a/app/components/users/form/persisted_fields.rb
+++ b/app/components/users/form/persisted_fields.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Users::Form::PersistedFields < Components::Base

--- a/app/components/users/pwd_form.rb
+++ b/app/components/users/pwd_form.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Components::Users::PwdForm < Components::Base

--- a/app/components/users/user.rb
+++ b/app/components/users/user.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Components::Users::User < Components::Base

--- a/app/constraints/authenticated_constraint.rb
+++ b/app/constraints/authenticated_constraint.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/actors_controller.rb
+++ b/app/controllers/actors_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/api/v1/auth/tokens_controller.rb
+++ b/app/controllers/api/v1/auth/tokens_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/api/v1/boosts_controller.rb
+++ b/app/controllers/api/v1/boosts_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/api/v1/likes_controller.rb
+++ b/app/controllers/api/v1/likes_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,6 +27,10 @@ class ApplicationController < ActionController::Base
   unless Rails.env.production?
     around_action :n_plus_one_detection
 
+    # `around_action` hands the rest of the request cycle in as a block, which
+    # nothing in the source declares -- without this annotation the bare
+    # `yield` below is Ruby::UnexpectedYield.
+    #: () { () -> void } -> void
     def n_plus_one_detection
       Prosopite.scan
       yield

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 
@@ -28,10 +29,12 @@ class ApplicationController < ActionController::Base
     around_action :n_plus_one_detection
 
     # `around_action` hands the rest of the request cycle in as a block, which
-    # nothing in the source declares -- without this annotation the bare
-    # `yield` below is Ruby::UnexpectedYield.
+    # nothing in the source declared -- without the annotation the bare `yield`
+    # below is Ruby::UnexpectedYield. The `(&)` is required: Sorbet reads the
+    # same `#:` comment and rejects a block in the signature when the `def` has
+    # no block parameter (srb.help/3552), even though Steep accepts it.
     #: () { () -> void } -> void
-    def n_plus_one_detection
+    def n_plus_one_detection(&)
       Prosopite.scan
       yield
     ensure

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/concerns/locale_switcher.rb
+++ b/app/controllers/concerns/locale_switcher.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/concerns/post_viewing.rb
+++ b/app/controllers/concerns/post_viewing.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/concerns/rate_limiting.rb
+++ b/app/controllers/concerns/rate_limiting.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/discord_controller.rb
+++ b/app/controllers/discord_controller.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/federails/application_controller.rb
+++ b/app/controllers/federails/application_controller.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/followings_controller.rb
+++ b/app/controllers/followings_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/madmin/active_storage/attachments_controller.rb
+++ b/app/controllers/madmin/active_storage/attachments_controller.rb
@@ -1,3 +1,4 @@
+# typed: true
 # rbs_inline: enabled
 
 module Madmin

--- a/app/controllers/madmin/application_controller.rb
+++ b/app/controllers/madmin/application_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # rbs_inline: enabled
 
 module Madmin

--- a/app/controllers/madmin/articles_controller.rb
+++ b/app/controllers/madmin/articles_controller.rb
@@ -1,3 +1,4 @@
+# typed: true
 # rbs_inline: enabled
 
 module Madmin

--- a/app/controllers/madmin/dashboard_controller.rb
+++ b/app/controllers/madmin/dashboard_controller.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/madmin/preferences_controller.rb
+++ b/app/controllers/madmin/preferences_controller.rb
@@ -1,3 +1,4 @@
+# typed: true
 # rbs_inline: enabled
 
 module Madmin

--- a/app/controllers/madmin/roles_controller.rb
+++ b/app/controllers/madmin/roles_controller.rb
@@ -1,3 +1,4 @@
+# typed: true
 # rbs_inline: enabled
 
 module Madmin

--- a/app/controllers/madmin/sites_controller.rb
+++ b/app/controllers/madmin/sites_controller.rb
@@ -1,3 +1,4 @@
+# typed: true
 # rbs_inline: enabled
 
 module Madmin

--- a/app/controllers/madmin/social_controller.rb
+++ b/app/controllers/madmin/social_controller.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/madmin/tags_controller.rb
+++ b/app/controllers/madmin/tags_controller.rb
@@ -1,3 +1,4 @@
+# typed: true
 # rbs_inline: enabled
 
 module Madmin

--- a/app/controllers/madmin/users_controller.rb
+++ b/app/controllers/madmin/users_controller.rb
@@ -1,3 +1,4 @@
+# typed: true
 # rbs_inline: enabled
 
 module Madmin

--- a/app/controllers/oauth_controller.rb
+++ b/app/controllers/oauth_controller.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -108,7 +108,10 @@ class ProfilesController < ApplicationController
       end
     end
 
-    #: () -> Hash[Symbol, untyped]
+    # A record type, not `Hash[Symbol, untyped]`: this is double-splatted into
+    # `Views::Profiles::ActivityList.new`, and Steep can only verify the
+    # required keywords are supplied when the exact keys are declared.
+    #: () -> { user: untyped, posts: untyped, pagy: untyped, liked_post_ids: untyped, boosted_post_ids: untyped }
     def post_list_args
       { user: @user, posts: @posts, pagy: @pagy,
         liked_post_ids: @liked_post_ids, boosted_post_ids: @boosted_post_ids }

--- a/app/controllers/push_subscriptions_controller.rb
+++ b/app/controllers/push_subscriptions_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/users/oauth_registrations_controller.rb
+++ b/app/controllers/users/oauth_registrations_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/functions/article_humanizer.rb
+++ b/app/functions/article_humanizer.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/functions/articles/date_parsing.rb
+++ b/app/functions/articles/date_parsing.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/functions/articles/hybrid_search.rb
+++ b/app/functions/articles/hybrid_search.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/functions/articles/query.rb
+++ b/app/functions/articles/query.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/functions/discord_notifier.rb
+++ b/app/functions/discord_notifier.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/functions/hosts.rb
+++ b/app/functions/hosts.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/functions/profiles/polymorphic_activity.rb
+++ b/app/functions/profiles/polymorphic_activity.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/functions/slack_notifier.rb
+++ b/app/functions/slack_notifier.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,4 @@
+# typed: false
 # rbs_inline: enabled
 
 module ApplicationHelper

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/jobs/article_batch_job.rb
+++ b/app/jobs/article_batch_job.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/jobs/article_batch_job.rb
+++ b/app/jobs/article_batch_job.rb
@@ -7,7 +7,10 @@ class ArticleBatchJob < ApplicationJob
 
   queue_as :default
 
-  #: (?Time created_at) -> void
+  # `Time.zone.now` returns an ActiveSupport::TimeWithZone, which only quacks
+  # like Time -- it is not a subclass -- so the default value does not satisfy
+  # a bare `Time` annotation.
+  #: (?(Time | ActiveSupport::TimeWithZone) created_at) -> void
   def perform(created_at = Time.zone.now.beginning_of_day)
     Article.kept.where(title_ko: nil, created_at: created_at...).limit(5).each do |article|
       unless check_rate_limit

--- a/app/jobs/article_job.rb
+++ b/app/jobs/article_job.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/jobs/article_reembed_job.rb
+++ b/app/jobs/article_reembed_job.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/jobs/discarded_article_cleanup_job.rb
+++ b/app/jobs/discarded_article_cleanup_job.rb
@@ -23,9 +23,12 @@ class DiscardedArticleCleanupJob < ApplicationJob
       article_ids = batch.pluck(:id)
       next if article_ids.empty?
 
-      nulled_posts = Post.where(article_id: article_ids).update_all(article_id: nil)
-      deleted_notifications = NotificationDelivery.where(article_id: article_ids).delete_all
-      deleted_articles = Article.where(id: article_ids).delete_all
+      # `update_all`/`delete_all` are typed `untyped` by the activerecord RBS,
+      # so `count += rows` resolves against every `Integer#+` overload and
+      # widens the counters to BigDecimal. Both actually return a row count.
+      nulled_posts = Post.where(article_id: article_ids).update_all(article_id: nil) #: Integer
+      deleted_notifications = NotificationDelivery.where(article_id: article_ids).delete_all #: Integer
+      deleted_articles = Article.where(id: article_ids).delete_all #: Integer
 
       nulled_posts_count += nulled_posts
       deleted_notifications_count += deleted_notifications

--- a/app/jobs/discord_article_delivery_job.rb
+++ b/app/jobs/discord_article_delivery_job.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/jobs/hacker_news_site_job.rb
+++ b/app/jobs/hacker_news_site_job.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/jobs/index_now_job.rb
+++ b/app/jobs/index_now_job.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/jobs/slack_article_delivery_job.rb
+++ b/app/jobs/slack_article_delivery_job.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/jobs/social_delete_job.rb
+++ b/app/jobs/social_delete_job.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/jobs/social_post_job.rb
+++ b/app/jobs/social_post_job.rb
@@ -7,7 +7,10 @@ class SocialPostJob < ApplicationJob
 
   queue_as :default
 
-  #: (?Integer? id, ?Time created_at) -> void
+  # `Time.zone.now` returns an ActiveSupport::TimeWithZone, which only quacks
+  # like Time -- it is not a subclass -- so the default value does not satisfy
+  # a bare `Time` annotation.
+  #: (?Integer? id, ?(Time | ActiveSupport::TimeWithZone) created_at) -> void
   def perform(id = nil, created_at = Time.zone.now.beginning_of_day)
     return unless Rails.env.production?
 

--- a/app/jobs/social_post_job.rb
+++ b/app/jobs/social_post_job.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/lib/json_failure_app.rb
+++ b/app/lib/json_failure_app.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/madmin/fields/lexxy_editor_field.rb
+++ b/app/madmin/fields/lexxy_editor_field.rb
@@ -1,3 +1,5 @@
+# typed: true
+
 class LexxyEditorField < Madmin::Field
   def searchable?
     options.fetch(:searchable, model.column_names.include?(attribute_name.to_s))

--- a/app/madmin/resources/active_storage/attachment_resource.rb
+++ b/app/madmin/resources/active_storage/attachment_resource.rb
@@ -1,3 +1,5 @@
+# typed: true
+
 class ActiveStorage::AttachmentResource < Madmin::Resource
   # Attributes
   attribute :id, form: false

--- a/app/madmin/resources/article_resource.rb
+++ b/app/madmin/resources/article_resource.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 class ArticleResource < Madmin::Resource
   # Attributes
   attribute :id, form: false

--- a/app/madmin/resources/preference_resource.rb
+++ b/app/madmin/resources/preference_resource.rb
@@ -1,3 +1,5 @@
+# typed: true
+
 class PreferenceResource < Madmin::Resource
   # Attributes
   attribute :id, form: false

--- a/app/madmin/resources/role_resource.rb
+++ b/app/madmin/resources/role_resource.rb
@@ -1,3 +1,5 @@
+# typed: true
+
 class RoleResource < Madmin::Resource
   # Attributes
   attribute :id, form: false

--- a/app/madmin/resources/site_resource.rb
+++ b/app/madmin/resources/site_resource.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 class SiteResource < Madmin::Resource
   # Attributes
   attribute :id, form: false

--- a/app/madmin/resources/tag_resource.rb
+++ b/app/madmin/resources/tag_resource.rb
@@ -1,3 +1,5 @@
+# typed: true
+
 class TagResource < Madmin::Resource
   # Attributes
   attribute :id, form: false

--- a/app/madmin/resources/user_resource.rb
+++ b/app/madmin/resources/user_resource.rb
@@ -1,3 +1,5 @@
+# typed: true
+
 class UserResource < Madmin::Resource
   # Attributes
   attribute :id, form: false

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/mailers/concerns/recipient_host_routing.rb
+++ b/app/mailers/concerns/recipient_host_routing.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/boost.rb
+++ b/app/models/boost.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/concerns/html_sanitizable.rb
+++ b/app/models/concerns/html_sanitizable.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/configs/apple_oauth.rb
+++ b/app/models/configs/apple_oauth.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/configs/discord.rb
+++ b/app/models/configs/discord.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/configs/github_oauth.rb
+++ b/app/models/configs/github_oauth.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/configs/google_oauth.rb
+++ b/app/models/configs/google_oauth.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/configs/oauth_base.rb
+++ b/app/models/configs/oauth_base.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/configs/slack.rb
+++ b/app/models/configs/slack.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/configs/web_push.rb
+++ b/app/models/configs/web_push.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/discord_channel.rb
+++ b/app/models/discord_channel.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/discord_delivery.rb
+++ b/app/models/discord_delivery.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/jwt_denylist.rb
+++ b/app/models/jwt_denylist.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/notification_channel.rb
+++ b/app/models/notification_channel.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/notification_delivery.rb
+++ b/app/models/notification_delivery.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/oauth_account.rb
+++ b/app/models/oauth_account.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/push_subscription.rb
+++ b/app/models/push_subscription.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/refresh_token.rb
+++ b/app/models/refresh_token.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/slack_channel.rb
+++ b/app/models/slack_channel.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/slack_delivery.rb
+++ b/app/models/slack_delivery.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/presenters/discord_article_presenter.rb
+++ b/app/presenters/discord_article_presenter.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/presenters/slack_article_presenter.rb
+++ b/app/presenters/slack_article_presenter.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/services/content_service.rb
+++ b/app/services/content_service.rb
@@ -57,7 +57,9 @@ class ContentService < OperationService
     logger.info "Youtube ID: #{youtube_id}"
     return Failure(:not_youtube) unless youtube_id
 
-    transcript = nil
+    # Declared up front, so without the annotation Steep pins the local to
+    # `nil` and rejects every later assignment in the blocks below.
+    transcript = nil #: String?
     video = Yt::Video.new id: youtube_id
     begin
       video.captions.map(&:language).each do |lang|

--- a/app/services/discord_delivery_service.rb
+++ b/app/services/discord_delivery_service.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/services/push_notification_service.rb
+++ b/app/services/push_notification_service.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/services/slack_delivery_service.rb
+++ b/app/services/slack_delivery_service.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/skills/humanize_korean/references/metrics.rb
+++ b/app/skills/humanize_korean/references/metrics.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/skills/humanize_korean/references/metrics_v2.rb
+++ b/app/skills/humanize_korean/references/metrics_v2.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/skills/humanize_korean/scripts/golden/checks.rb
+++ b/app/skills/humanize_korean/scripts/golden/checks.rb
@@ -101,6 +101,10 @@ module HumanizeKoreanGoldenChecks
       failures
     end
 
+    # Annotated so `line` below is a String: with `text` untyped, `line.length`
+    # is untyped too and `offset + untyped` resolves against every `Integer#+`
+    # overload, widening the offset accumulator to BigDecimal.
+    #: (String) -> Array[untyped]
     def extract_inline_markers(text)
       markers = []
       offset = 0

--- a/app/skills/humanize_korean/scripts/golden/checks.rb
+++ b/app/skills/humanize_korean/scripts/golden/checks.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/skills/humanize_korean/scripts/prepare_monolith_input.rb
+++ b/app/skills/humanize_korean/scripts/prepare_monolith_input.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/skills/humanize_korean/scripts/reassemble_chunks.rb
+++ b/app/skills/humanize_korean/scripts/reassemble_chunks.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/skills/humanize_korean/scripts/verify_gates.rb
+++ b/app/skills/humanize_korean/scripts/verify_gates.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/tools/get_existing_tags.rb
+++ b/app/tools/get_existing_tags.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/tools/search_related_articles.rb
+++ b/app/tools/search_related_articles.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/tools/validate_slug.rb
+++ b/app/tools/validate_slug.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/views/activities/feed.rb
+++ b/app/views/activities/feed.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Activities::Feed < Views::Base

--- a/app/views/actors/gone.rb
+++ b/app/views/actors/gone.rb
@@ -1,3 +1,4 @@
+# typed: true
 # app/views/actors/gone.rb
 # frozen_string_literal: true
 

--- a/app/views/actors/lookup.rb
+++ b/app/views/actors/lookup.rb
@@ -1,3 +1,4 @@
+# typed: true
 # app/views/actors/lookup.rb
 # frozen_string_literal: true
 

--- a/app/views/actors/show.rb
+++ b/app/views/actors/show.rb
@@ -1,3 +1,4 @@
+# typed: true
 # app/views/actors/show.rb
 # frozen_string_literal: true
 

--- a/app/views/articles/index.rb
+++ b/app/views/articles/index.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Articles::Index < Views::Base

--- a/app/views/articles/new.rb
+++ b/app/views/articles/new.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Articles::New < Views::Base

--- a/app/views/articles/others.rb
+++ b/app/views/articles/others.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Articles::Others < Views::Base

--- a/app/views/articles/show.rb
+++ b/app/views/articles/show.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Views::Articles::Show < Views::Base

--- a/app/views/articles/tagged.rb
+++ b/app/views/articles/tagged.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Articles::Tagged < Views::Base

--- a/app/views/base.rb
+++ b/app/views/base.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Base < Components::Base

--- a/app/views/blog_posts/edit.rb
+++ b/app/views/blog_posts/edit.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Views::BlogPosts::Edit < Views::Base

--- a/app/views/blog_posts/index.rb
+++ b/app/views/blog_posts/index.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::BlogPosts::Index < Views::Base

--- a/app/views/boosts/toggle_turbo_stream.rb
+++ b/app/views/boosts/toggle_turbo_stream.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Boosts::ToggleTurboStream < Views::Base

--- a/app/views/confirmations/new.rb
+++ b/app/views/confirmations/new.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Confirmations::New < Views::Base

--- a/app/views/devise/mailer/confirmation_instructions.rb
+++ b/app/views/devise/mailer/confirmation_instructions.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Devise::Mailer::ConfirmationInstructions < Views::Base

--- a/app/views/followings/follow_actions.rb
+++ b/app/views/followings/follow_actions.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Followings::FollowActions < Views::Base

--- a/app/views/home/about.rb
+++ b/app/views/home/about.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Home::About < Views::Base

--- a/app/views/home/index.rb
+++ b/app/views/home/index.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Home::Index < Views::Base

--- a/app/views/home/privacy_policy.rb
+++ b/app/views/home/privacy_policy.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Home::PrivacyPolicy < Views::Base

--- a/app/views/home/terms.rb
+++ b/app/views/home/terms.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Home::Terms < Views::Base

--- a/app/views/likes/toggle_turbo_stream.rb
+++ b/app/views/likes/toggle_turbo_stream.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Likes::ToggleTurboStream < Views::Base

--- a/app/views/oauth/result.rb
+++ b/app/views/oauth/result.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Oauth::Result < Views::Base

--- a/app/views/passwords/edit.rb
+++ b/app/views/passwords/edit.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Passwords::Edit < Views::Base

--- a/app/views/passwords/new.rb
+++ b/app/views/passwords/new.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Passwords::New < Views::Base

--- a/app/views/posts/create_turbo_stream.rb
+++ b/app/views/posts/create_turbo_stream.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Posts::CreateTurboStream < Views::Base

--- a/app/views/posts/show.rb
+++ b/app/views/posts/show.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Views::Posts::Show < Views::Base

--- a/app/views/profiles/activity_list.rb
+++ b/app/views/profiles/activity_list.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/app/views/profiles/boost_list.rb
+++ b/app/views/profiles/boost_list.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Profiles::BoostList < Views::Base

--- a/app/views/profiles/follow_list.rb
+++ b/app/views/profiles/follow_list.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Profiles::FollowList < Views::Base

--- a/app/views/profiles/like_list.rb
+++ b/app/views/profiles/like_list.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Profiles::LikeList < Views::Base

--- a/app/views/profiles/show.rb
+++ b/app/views/profiles/show.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Profiles::Show < Views::Base

--- a/app/views/sessions/new.rb
+++ b/app/views/sessions/new.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Sessions::New < Views::Base

--- a/app/views/users/edit.rb
+++ b/app/views/users/edit.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Users::Edit < Views::Base

--- a/app/views/users/new.rb
+++ b/app/views/users/new.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Users::New < Views::Base

--- a/app/views/users/oauth_signup.rb
+++ b/app/views/users/oauth_signup.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Users::OauthSignup < Views::Base

--- a/app/views/users/password.rb
+++ b/app/views/users/password.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 class Views::Users::Password < Views::Base

--- a/app/views/users/show.rb
+++ b/app/views/users/show.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class Views::Users::Show < Views::Base

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,9 +5,16 @@ pre-commit:
   parallel: false
   commands:
     # 스테이징한 .rb 파일만 자동 수정하고, 수정 결과를 이번 커밋에 포함한다.
+    #
+    # --force-exclusion 이 없으면 .rubocop.yml 의 AllCops/Exclude 가 무시된다.
+    # RuboCop 은 파일을 인자로 명시하면 "사용자가 일부러 지목했다"고 보고 제외
+    # 목록을 건너뛰기 때문이다. 여기서는 항상 경로를 넘기므로 app/components,
+    # app/views, lib 전체가 검사 대상이 되어 `bundle exec rubocop` 과 결과가
+    # 갈렸다. -A 는 unsafe 수정까지 하므로 제외 대상인 vendored 컴포넌트가
+    # 조용히 재포맷되기도 했다.
     rubocop:
       glob: "*.{rb,rake,gemspec}"
-      run: bundle exec rubocop -A {staged_files}
+      run: bundle exec rubocop -A --force-exclusion {staged_files}
       stage_fixed: true
     # 인라인 RBS를 생성하고, 생성/변경된 시그니처를 이번 커밋에 포함한다.
     # stage_fixed는 기존 스테이징 파일의 수정만 다시 스테이징하므로,

--- a/lib/quality/coverage_parser.rb
+++ b/lib/quality/coverage_parser.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/lib/quality/coverage_snapshot.rb
+++ b/lib/quality/coverage_snapshot.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/lib/quality/flog_parser.rb
+++ b/lib/quality/flog_parser.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/lib/quality/report.rb
+++ b/lib/quality/report.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/lib/quality/rubocop_parser.rb
+++ b/lib/quality/rubocop_parser.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/lib/schema_dot_org/creative_work.rb
+++ b/lib/schema_dot_org/creative_work.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/lib/schema_dot_org/news_article.rb
+++ b/lib/schema_dot_org/news_article.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/lib/schema_dot_org/news_media_organization.rb
+++ b/lib/schema_dot_org/news_media_organization.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/lib/schema_dot_org/speakable_specification.rb
+++ b/lib/schema_dot_org/speakable_specification.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 # rbs_inline: enabled
 

--- a/sig/generated/controllers/application_controller.rbs
+++ b/sig/generated/controllers/application_controller.rbs
@@ -4,8 +4,10 @@ class ApplicationController < ActionController::Base
   include LocaleSwitcher
 
   # `around_action` hands the rest of the request cycle in as a block, which
-  # nothing in the source declares -- without this annotation the bare
-  # `yield` below is Ruby::UnexpectedYield.
+  # nothing in the source declared -- without the annotation the bare `yield`
+  # below is Ruby::UnexpectedYield. The `(&)` is required: Sorbet reads the
+  # same `#:` comment and rejects a block in the signature when the `def` has
+  # no block parameter (srb.help/3552), even though Steep accepts it.
   # : () { () -> void } -> void
   def n_plus_one_detection: () { () -> void } -> void
 

--- a/sig/generated/controllers/application_controller.rbs
+++ b/sig/generated/controllers/application_controller.rbs
@@ -3,7 +3,11 @@
 class ApplicationController < ActionController::Base
   include LocaleSwitcher
 
-  def n_plus_one_detection: () -> untyped
+  # `around_action` hands the rest of the request cycle in as a block, which
+  # nothing in the source declares -- without this annotation the bare
+  # `yield` below is Ruby::UnexpectedYield.
+  # : () { () -> void } -> void
+  def n_plus_one_detection: () { () -> void } -> void
 
   private
 

--- a/sig/generated/controllers/profiles_controller.rbs
+++ b/sig/generated/controllers/profiles_controller.rbs
@@ -28,8 +28,11 @@ class ProfilesController < ApplicationController
   # : (Symbol) -> Views::Base
   def activity_list_component: (Symbol) -> Views::Base
 
-  # : () -> Hash[Symbol, untyped]
-  def post_list_args: () -> Hash[Symbol, untyped]
+  # A record type, not `Hash[Symbol, untyped]`: this is double-splatted into
+  # `Views::Profiles::ActivityList.new`, and Steep can only verify the
+  # required keywords are supplied when the exact keys are declared.
+  # : () -> { user: untyped, posts: untyped, pagy: untyped, liked_post_ids: untyped, boosted_post_ids: untyped }
+  def post_list_args: () -> { user: untyped, posts: untyped, pagy: untyped, liked_post_ids: untyped, boosted_post_ids: untyped }
 
   def render_show_with_activity: (active_tab: untyped) -> untyped
 

--- a/sig/generated/jobs/article_batch_job.rbs
+++ b/sig/generated/jobs/article_batch_job.rbs
@@ -3,8 +3,11 @@
 class ArticleBatchJob < ApplicationJob
   include JobRateLimiting
 
-  # : (?Time created_at) -> void
-  def perform: (?Time created_at) -> void
+  # `Time.zone.now` returns an ActiveSupport::TimeWithZone, which only quacks
+  # like Time -- it is not a subclass -- so the default value does not satisfy
+  # a bare `Time` annotation.
+  # : (?(Time | ActiveSupport::TimeWithZone) created_at) -> void
+  def perform: (?Time | ActiveSupport::TimeWithZone created_at) -> void
 
   private
 

--- a/sig/generated/jobs/social_post_job.rbs
+++ b/sig/generated/jobs/social_post_job.rbs
@@ -3,8 +3,11 @@
 class SocialPostJob < ApplicationJob
   include JobRateLimiting
 
-  # : (?Integer? id, ?Time created_at) -> void
-  def perform: (?Integer? id, ?Time created_at) -> void
+  # `Time.zone.now` returns an ActiveSupport::TimeWithZone, which only quacks
+  # like Time -- it is not a subclass -- so the default value does not satisfy
+  # a bare `Time` annotation.
+  # : (?Integer? id, ?(Time | ActiveSupport::TimeWithZone) created_at) -> void
+  def perform: (?Integer? id, ?Time | ActiveSupport::TimeWithZone created_at) -> void
 
   # : () -> Integer
   def rate_limit_threshold: () -> Integer

--- a/sig/generated/skills/humanize_korean/scripts/golden/checks.rbs
+++ b/sig/generated/skills/humanize_korean/scripts/golden/checks.rbs
@@ -53,7 +53,11 @@ module HumanizeKoreanGoldenChecks
 
   def self.check_headings: (untyped original, untyped output) -> untyped
 
-  def self.extract_inline_markers: (untyped text) -> untyped
+  # Annotated so `line` below is a String: with `text` untyped, `line.length`
+  # is untyped too and `offset + untyped` resolves against every `Integer#+`
+  # overload, widening the offset accumulator to BigDecimal.
+  # : (String) -> Array[untyped]
+  def self.extract_inline_markers: (String) -> Array[untyped]
 
   def self.extract_defs: (untyped text) -> untyped
 

--- a/sig/shims/external.rbs
+++ b/sig/shims/external.rbs
@@ -66,7 +66,19 @@ module Federails
   module ActorEntity
   end
 
+  # `rbs_collection.yaml` sets `federails: ignore: true` because the gem's
+  # checked-in signatures reference undeclared Pagy/Alba types, so the concern
+  # arrives here empty. Article and Post override these three and call `super`,
+  # which without a declaration is Ruby::UnexpectedSuper -- and makes Steep
+  # read the `actor:`/`to:`/`cc:` keywords as a record type it cannot resolve
+  # (Ruby::UnknownRecordKey). Copied from the gem's own
+  # sig/generated/models/concerns/federails/data_entity.rbs.
   module DataEntity
+    def create_federails_activity: (untyped action, ?actor: untyped, ?to: untyped, ?cc: untyped) -> untyped
+
+    def set_federails_actor: () -> Federails::Actor?
+
+    def federails_actor: () -> Federails::Actor?
   end
 
   module HandlesSocialActivities
@@ -113,11 +125,14 @@ module Components
   class Base
   end
 
-  # Zeitwerk defines namespace modules implicitly from the directory layout, so
-  # components written in compact form (`class Components::Layout::Foo`) have no
-  # `module` keyword for rbs-inline to pick up. Declare them here, same as
-  # `Views::Profiles` above.
-  module Layout
+  # `Components::Layout` is both a real component (`class Components::Layout <
+  # Components::Base` in app/components/layout.rb) and the namespace its
+  # children are written under in compact form (`class
+  # Components::Layout::AssetPreloads`). It has no generated signature -- only
+  # nested components under app/components/layout/ do -- so declare it here.
+  # Must be a `class`, not a `module`: declaring it as a module contradicts the
+  # source and raises Ruby::ClassModuleMismatch.
+  class Layout < Base
   end
 end
 
@@ -199,4 +214,44 @@ module Phlex
       end
     end
   end
+end
+
+# The pinned activestorage 7.0 RBS predates Rails 7.1's named-variants block
+# form (`has_one_attached :thumbnail do |attachable| ... end`), so calling it
+# with a block raises Ruby::UnexpectedBlockGiven. Append an overload with
+# `| ...` rather than redefining, so the collection's own signature survives.
+module ActiveStorage
+  module Attached::Model
+    module ClassMethods
+      def has_one_attached: (
+        (::String | ::Symbol) name,
+        ?dependent: ::Symbol,
+        ?service: (::String | ::Symbol | nil),
+        ?strict_loading: bool
+      ) { (untyped attachable) -> void } -> void | ...
+    end
+  end
+end
+
+# ActiveSupport's generated RBS narrows `Range#sum` to the blockless
+# arithmetic-progression fast path, which shadows `Enumerable#sum`'s block
+# form and makes `(0...n).sum { ... }` a Ruby::UnexpectedBlockGiven. The real
+# method falls back to `super` whenever a block is given, so append that
+# overload back with `| ...`.
+class Range[out Elem]
+  def sum: [T] (?untyped identity) { (Elem) -> T } -> untyped | ...
+end
+
+# The web-push 3.0 RBS types the `vapid:` argument as a closed record with only
+# subject/public_key/private_key, so passing the gem's supported `expiration`
+# key is a Ruby::UnknownRecordKey. Append the wider record with `| ...`.
+module WebPush
+  def self.payload_send: (
+    ?message: String,
+    endpoint: String,
+    ?p256dh: String,
+    ?auth: String,
+    ?vapid: { subject: String, public_key: String, private_key: String, expiration: untyped },
+    **untyped
+  ) -> untyped | ...
 end

--- a/test/agents/article_agent_test.rb
+++ b/test/agents/article_agent_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/clients/discord_client_test.rb
+++ b/test/clients/discord_client_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/clients/mastodon_client_test.rb
+++ b/test/clients/mastodon_client_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/clients/reddit_test.rb
+++ b/test/clients/reddit_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/clients/rss_client_test.rb
+++ b/test/clients/rss_client_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/clients/ruby_conference_test.rb
+++ b/test/clients/ruby_conference_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/clients/twitter_client_test.rb
+++ b/test/clients/twitter_client_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/clients/youtube/channel_test.rb
+++ b/test/clients/youtube/channel_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/components/layout_asset_preconnect_test.rb
+++ b/test/components/layout_asset_preconnect_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/components/lexxy_loading_test.rb
+++ b/test/components/lexxy_loading_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/actors_controller_test.rb
+++ b/test/controllers/actors_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # test/controllers/actors_controller_test.rb
 # frozen_string_literal: true
 

--- a/test/controllers/api/v1/articles_controller_test.rb
+++ b/test/controllers/api/v1/articles_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/api/v1/auth/tokens_controller_test.rb
+++ b/test/controllers/api/v1/auth/tokens_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/blog_posts_controller_test.rb
+++ b/test/controllers/blog_posts_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/blogs_controller_test.rb
+++ b/test/controllers/blogs_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/boosts_controller_test.rb
+++ b/test/controllers/boosts_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/confirmations_controller_test.rb
+++ b/test/controllers/confirmations_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/discord_controller_test.rb
+++ b/test/controllers/discord_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/feed_controller_test.rb
+++ b/test/controllers/feed_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # test/controllers/activities_controller_test.rb
 # frozen_string_literal: true
 

--- a/test/controllers/followings_controller_test.rb
+++ b/test/controllers/followings_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/likes_controller_test.rb
+++ b/test/controllers/likes_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/madmin/preferences_controller_test.rb
+++ b/test/controllers/madmin/preferences_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/oauth_controller_test.rb
+++ b/test/controllers/oauth_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/push_subscriptions_controller_test.rb
+++ b/test/controllers/push_subscriptions_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/slack_controller_test.rb
+++ b/test/controllers/slack_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/social_controller_test.rb
+++ b/test/controllers/social_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/users/oauth_registrations_controller_test.rb
+++ b/test/controllers/users/oauth_registrations_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/users/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/users/omniauth_callbacks_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/users/passwords_controller_test.rb
+++ b/test/controllers/users/passwords_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/users/registrations_controller_test.rb
+++ b/test/controllers/users/registrations_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/controllers/users/sessions_controller_test.rb
+++ b/test/controllers/users/sessions_controller_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/functions/articles/agent_runner_test.rb
+++ b/test/functions/articles/agent_runner_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/functions/articles/date_parsing_test.rb
+++ b/test/functions/articles/date_parsing_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/functions/articles/hybrid_search_config_test.rb
+++ b/test/functions/articles/hybrid_search_config_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/functions/articles/hybrid_search_test.rb
+++ b/test/functions/articles/hybrid_search_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/functions/articles/markdown_test.rb
+++ b/test/functions/articles/markdown_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/functions/articles/query_test.rb
+++ b/test/functions/articles/query_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/functions/articles/search_test.rb
+++ b/test/functions/articles/search_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/functions/hosts_test.rb
+++ b/test/functions/hosts_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/functions/oauth_accounts/callbacks_test.rb
+++ b/test/functions/oauth_accounts/callbacks_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/functions/oauth_accounts/registration_test.rb
+++ b/test/functions/oauth_accounts/registration_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/functions/rss/page_crawler_test.rb
+++ b/test/functions/rss/page_crawler_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/functions/search/benchmark_test.rb
+++ b/test/functions/search/benchmark_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/functions/sitemap_builder_test.rb
+++ b/test/functions/sitemap_builder_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/integration/rendered_body_sanitization_test.rb
+++ b/test/integration/rendered_body_sanitization_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/integration/seeds_test.rb
+++ b/test/integration/seeds_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/jobs/article_batch_job_test.rb
+++ b/test/jobs/article_batch_job_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/jobs/article_job_test.rb
+++ b/test/jobs/article_job_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/jobs/article_thumbnail_job_test.rb
+++ b/test/jobs/article_thumbnail_job_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/jobs/discarded_article_cleanup_job_test.rb
+++ b/test/jobs/discarded_article_cleanup_job_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/jobs/discord_article_delivery_job_test.rb
+++ b/test/jobs/discord_article_delivery_job_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/jobs/gmail_article_job_test.rb
+++ b/test/jobs/gmail_article_job_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/jobs/hacker_news_site_job_test.rb
+++ b/test/jobs/hacker_news_site_job_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/jobs/index_now_job_test.rb
+++ b/test/jobs/index_now_job_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/jobs/reddit_site_job_test.rb
+++ b/test/jobs/reddit_site_job_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/jobs/reply_notification_job_test.rb
+++ b/test/jobs/reply_notification_job_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/jobs/rss_site_job_test.rb
+++ b/test/jobs/rss_site_job_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/jobs/rss_site_page_job_test.rb
+++ b/test/jobs/rss_site_page_job_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/jobs/slack_article_delivery_job_test.rb
+++ b/test/jobs/slack_article_delivery_job_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/jobs/social_post_job_test.rb
+++ b/test/jobs/social_post_job_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/jobs/youtube_site_job_test.rb
+++ b/test/jobs/youtube_site_job_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/lib/madmin_importmap_test.rb
+++ b/test/lib/madmin_importmap_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/lib/quality/coverage_snapshot_test.rb
+++ b/test/lib/quality/coverage_snapshot_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/mailers/application_mailer_test.rb
+++ b/test/mailers/application_mailer_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/mailers/devise_mailer_test.rb
+++ b/test/mailers/devise_mailer_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/models/application_record_test.rb
+++ b/test/models/application_record_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -816,7 +816,9 @@ class ArticleTest < ActiveSupport::TestCase
     article.summary_key = nil
     article.tag_list = "ruby, rails"
 
-    captured = nil
+    # Pinned to `nil` by the initial assignment otherwise, which rejects the
+    # assignment made inside the block below.
+    captured = nil #: Hash[Symbol, untyped]?
     Federails::DataTransformer::Note.stub(:to_federation, ->(entity, name:, content:, custom:) { captured = { entity:, name:, content:, custom: }; { "ok" => true } }) do
       article.to_activitypub_object
     end
@@ -836,7 +838,9 @@ class ArticleTest < ActiveSupport::TestCase
     blob = ActiveStorage::Blob.create_and_upload!(io: StringIO.new("fake image data"), filename: "test.jpg", content_type: "image/jpeg")
     article.thumbnail.attach(blob)
 
-    captured = nil
+    # Pinned to `nil` by the initial assignment otherwise, which rejects the
+    # assignment made inside the block below.
+    captured = nil #: Hash[Symbol, untyped]?
     Federails::DataTransformer::Note.stub(:to_federation, ->(entity, name:, content:, custom:) { captured = { entity:, name:, content:, custom: }; { "ok" => true } }) do
       article.to_activitypub_object
     end
@@ -856,7 +860,9 @@ class ArticleTest < ActiveSupport::TestCase
     article.title_ko = "썸네일 없음"
     article.summary_key = [ "요약" ]
 
-    captured = nil
+    # Pinned to `nil` by the initial assignment otherwise, which rejects the
+    # assignment made inside the block below.
+    captured = nil #: Hash[Symbol, untyped]?
     Federails::DataTransformer::Note.stub(:to_federation, ->(entity, name:, content:, custom:) { captured = { entity:, name:, content:, custom: }; { "ok" => true } }) do
       article.to_activitypub_object
     end

--- a/test/models/boost_test.rb
+++ b/test/models/boost_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/models/concerns/localized_display_test.rb
+++ b/test/models/concerns/localized_display_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/models/concerns/posts/federation_ingest_test.rb
+++ b/test/models/concerns/posts/federation_ingest_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/models/configs/apple_oauth_test.rb
+++ b/test/models/configs/apple_oauth_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/models/configs/github_oauth_test.rb
+++ b/test/models/configs/github_oauth_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/models/configs/google_oauth_test.rb
+++ b/test/models/configs/google_oauth_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/models/jwt_denylist_test.rb
+++ b/test/models/jwt_denylist_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/models/like_test.rb
+++ b/test/models/like_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/models/notification_channel_test.rb
+++ b/test/models/notification_channel_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/models/oauth_account_test.rb
+++ b/test/models/oauth_account_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -548,7 +548,9 @@ class PostTest < ActiveSupport::TestCase
     )
     post.tag_list = "ruby, rails"
 
-    captured = nil
+    # Pinned to `nil` by the initial assignment otherwise, which rejects the
+    # assignment made inside the block below.
+    captured = nil #: Hash[Symbol, untyped]?
     Federails::DataTransformer::Note.stub(:to_federation, ->(record, content:, name:, custom:) { captured = { record:, content:, name:, custom: }; { "ok" => true } }) do
       post.to_activitypub_object
     end
@@ -564,7 +566,9 @@ class PostTest < ActiveSupport::TestCase
   test "to_activitypub_object는 parent가 없으면 article을 inReplyTo로 사용한다" do
     post = Post.create!(body: "기사 댓글", user: @user, article: @article)
 
-    captured = nil
+    # Pinned to `nil` by the initial assignment otherwise, which rejects the
+    # assignment made inside the block below.
+    captured = nil #: Hash[Symbol, untyped]?
     Federails::DataTransformer::Note.stub(:to_federation, ->(_record, content:, name:, custom:) { captured = { content:, name:, custom: }; { "ok" => true } }) do
       post.to_activitypub_object
     end
@@ -651,7 +655,9 @@ class PostTest < ActiveSupport::TestCase
   test "to_activitypub_object는 장문을 요약과 제목과 원문 링크로 전달한다" do
     post = posts(:blog_published)
 
-    captured = nil
+    # Pinned to `nil` by the initial assignment otherwise, which rejects the
+    # assignment made inside the block below.
+    captured = nil #: Hash[Symbol, untyped]?
     Federails::DataTransformer::Note.stub(:to_federation, ->(record, content:, name:, custom:) { captured = { record:, content:, name:, custom: }; { "ok" => true } }) do
       post.to_activitypub_object
     end
@@ -682,7 +688,9 @@ class PostTest < ActiveSupport::TestCase
   test "to_activitypub_object는 단문 본문 전체 발행을 유지한다" do
     post = @root_post
 
-    captured = nil
+    # Pinned to `nil` by the initial assignment otherwise, which rejects the
+    # assignment made inside the block below.
+    captured = nil #: Hash[Symbol, untyped]?
     Federails::DataTransformer::Note.stub(:to_federation, ->(_record, content:, name:, custom:) { captured = { content:, name:, custom: }; { "ok" => true } }) do
       post.to_activitypub_object
     end

--- a/test/models/preference_test.rb
+++ b/test/models/preference_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/models/push_subscription_test.rb
+++ b/test/models/push_subscription_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/models/refresh_token_test.rb
+++ b/test/models/refresh_token_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/presenters/discord_article_presenter_test.rb
+++ b/test/presenters/discord_article_presenter_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/presenters/slack_article_presenter_test.rb
+++ b/test/presenters/slack_article_presenter_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/services/active_storage_r2_cdn_patch_test.rb
+++ b/test/services/active_storage_r2_cdn_patch_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/services/article_agents_service_test.rb
+++ b/test/services/article_agents_service_test.rb
@@ -35,7 +35,9 @@ class ArticleAgentsServiceTest < ActiveSupport::TestCase
     content_service = Object.new
     content_service.define_singleton_method(:call) { |_article = nil| Dry::Monads::Failure(:no_content) }
 
-    result = nil
+    # Pinned to `nil` by the initial assignment otherwise, which rejects the
+    # assignment made inside the block below.
+    result = nil #: Dry::Monads::Result?
     ContentService.stub(:new, -> { content_service }) do
       result = ArticleAgentsService.new.call(article)
     end
@@ -103,7 +105,9 @@ class ArticleAgentsServiceTest < ActiveSupport::TestCase
 
     embed_result = Struct.new(:vectors).new(Array.new(3072, 0.0))
 
-    result = nil
+    # Pinned to `nil` by the initial assignment otherwise, which rejects the
+    # assignment made inside the block below.
+    result = nil #: Dry::Monads::Result?
     RubyLLM.stub(:embed, ->(*, **) { embed_result }) do
       ArticleAgent.stub(:new, agent) do
         HumanMonolithAgent.stub(:chat, humanize_chat) do
@@ -165,7 +169,9 @@ class ArticleAgentsServiceTest < ActiveSupport::TestCase
     service.define_singleton_method(:run_humanize) { |a| Dry::Monads::Success(a) }
     service.define_singleton_method(:run_thumbnail) { |a| Dry::Monads::Success(a) }
 
-    result = nil
+    # Pinned to `nil` by the initial assignment otherwise, which rejects the
+    # assignment made inside the block below.
+    result = nil #: Dry::Monads::Result?
     Articles::AgentRunner.stub(:run, ->(**) { Dry::Monads::Success(article) }) do
       result = service.call(article)
     end

--- a/test/services/article_agents_service_test.rb
+++ b/test/services/article_agents_service_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 # rbs_inline: enabled

--- a/test/services/articles/metadata_preparation_service_test.rb
+++ b/test/services/articles/metadata_preparation_service_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/services/content_service_test.rb
+++ b/test/services/content_service_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 # rbs_inline: enabled

--- a/test/services/discord_delivery_service_test.rb
+++ b/test/services/discord_delivery_service_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/services/discord_notifier_test.rb
+++ b/test/services/discord_notifier_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/services/index_now_service_test.rb
+++ b/test/services/index_now_service_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/services/mastodon_service_test.rb
+++ b/test/services/mastodon_service_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 # rbs_inline: enabled

--- a/test/services/oauth_client_test.rb
+++ b/test/services/oauth_client_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 # rbs_inline: enabled

--- a/test/services/push_notification_service_test.rb
+++ b/test/services/push_notification_service_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/services/slack_client_test.rb
+++ b/test/services/slack_client_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/services/slack_delivery_service_test.rb
+++ b/test/services/slack_delivery_service_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/services/slack_notifier_test.rb
+++ b/test/services/slack_notifier_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/services/social_media_service_test.rb
+++ b/test/services/social_media_service_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 # rbs_inline: enabled

--- a/test/services/twitter_service_test.rb
+++ b/test/services/twitter_service_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 # rbs_inline: enabled

--- a/test/system/article_browsing_test.rb
+++ b/test/system/article_browsing_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "application_system_test_case"

--- a/test/system/authentication_test.rb
+++ b/test/system/authentication_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "application_system_test_case"

--- a/test/system/blog_posts_test.rb
+++ b/test/system/blog_posts_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "application_system_test_case"

--- a/test/system/boosts_test.rb
+++ b/test/system/boosts_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "application_system_test_case"

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "application_system_test_case"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require_relative "../lib/quality/coverage_snapshot"


### PR DESCRIPTION
> #903 위에 쌓인 PR입니다. #903 머지 후 base가 main으로 자동 전환됩니다.

## Sorbet 게이트는 지금까지 타입을 하나도 검사하지 않았다

CI에 `srb tc`가 있지만 실질적으로 구문 오류·상수 해석·RBI 드리프트만 잡고 있었다. app/lib/test의 **481개 파일 중 시길이 있는 건 85개뿐이었고, 그마저 전부 `# typed: false`**였다. 나머지 396개는 시길이 없어 Sorbet 기본값인 false로 취급됐다.

## 11배 차이는 전부 "안 보여서" 생긴 것이었다

`spoom srb bump --dry`는 **시길이 없는 파일을 상향 후보로 평가조차 하지 않는다.**

| | 상향 가능 파일 |
|---|---|
| 있는 그대로 측정 | **27** |
| 모든 파일에 `# typed: false` 명시 후 재측정 | **296** |

즉 269개 파일이 "타입 검사를 통과할 수 있는데 아무도 물어보지 않아서" false에 머물러 있었다.

## 변경

1. 시길 없던 **393개 파일에 `# typed: false` 추가.** Sorbet가 이미 가정하던 값이라 의미상 무변경 — 측정 가능해질 뿐이다. `lib/protobuf`는 `sorbet/config`가 `--ignore` 하므로 제외했다.
2. 그중 **296개를 `# typed: true`로 상향.** spoom이 파일별로 타입 검사해 에러 0인 것만 고른다.

결과: **true 296 / false 185.** `typed: true` 파일에서는 이제 시그니처와 상수·메서드 해석이 실제로 강제된다. 참고로 481개 전부를 true로 올리면 894 에러다.

## 덤: pre-commit 훅의 rubocop 버그

이 변경을 커밋하려다 발견했다. 훅이 `bundle exec rubocop -A {staged_files}`로 도는데, **파일을 인자로 명시하면 RuboCop이 `AllCops/Exclude`를 건너뛴다** — "사용자가 일부러 지목했다"고 보기 때문이다.

`.rubocop.yml`은 `app/components/**`, `app/views/**`, `lib/**`를 제외하고 있는데 훅에서는 전부 검사 대상이 됐고, `-A`는 unsafe 수정까지 하므로 **제외 대상인 vendored ruby_ui 컴포넌트가 조용히 재포맷**되고 있었다. 평소엔 스테이징 파일이 적어 드러나지 않다가 481개를 올리니 표면화됐다 (훅 421개 검사 → 39곳 자동수정 + 7곳 실패로 커밋 중단).

`--force-exclusion`을 추가해 훅과 `bundle exec rubocop`의 결과를 일치시켰다. 적용 후 훅은 421개 대신 233개를 검사하고 무위반으로 통과한다.

## 다음 회차

`bundle exec spoom srb bump . --dry`를 다시 돌리면 남은 185개 중 상향 가능한 것이 나온다. 주의: **새로 만드는 파일은 시길이 없으면 여전히 false로 조용히 빠진다** — CI 주석에 적어뒀다.

## 검증

- `bundle exec srb tc` → No errors
- `bundle exec steep check` → No type error detected
- `bundle exec rbs -I sig validate` → 통과
- `bin/rails test` → 950 runs, 0 failures, 0 errors
- `bundle exec rspec` → 59 examples, 0 failures
- `bundle exec rubocop` → 365 files, no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUPLdoAC2L4qYJBkwrotaj
