### PR TITLE
Convert value-object Structs to Data

### DIFF
--- a/app/services/mastodon_service.rb
+++ b/app/services/mastodon_service.rb
@@ -3,10 +3,11 @@
 # rbs_inline: enabled
 
 class MastodonService < SocialMediaService
-  MastodonConfig = Struct.new(:character_limit, :url_length_counted, :formatting_buffer) do
-    def max_content_length
-      character_limit - formatting_buffer
-    end
+  MastodonConfig = Data.define(:character_limit, :url_length_counted, :formatting_buffer)
+
+  class MastodonConfig
+    #: () -> Integer
+    def max_content_length = character_limit - formatting_buffer
   end
 
   # Mastodon의 기본 문자 제한은 500자 (인스턴스마다 다를 수 있음)
@@ -70,7 +71,7 @@ class MastodonService < SocialMediaService
 
     # Mastodon은 URL을 실제 길이로 계산하므로 링크 길이도 포함
     reserved_space = tags.length + link.length + 5 # 공백과 줄바꿈
-    available_content_length = MASTODON_CONFIG.character_limit - MASTODON_CONFIG.formatting_buffer - reserved_space
+    available_content_length = MASTODON_CONFIG.max_content_length - reserved_space
 
     truncated_content = content.truncate([ available_content_length, 1 ].max, omission: "...")
     "#{truncated_content}\n\n#{tags}\n#{link}"

--- a/app/services/twitter_service.rb
+++ b/app/services/twitter_service.rb
@@ -3,10 +3,11 @@
 # rbs_inline: enabled
 
 class TwitterService < SocialMediaService
-  TwitterConfig = Struct.new(:character_limit, :shortened_url_length, :formatting_buffer) do
-    def max_content_length
-      character_limit - shortened_url_length - formatting_buffer
-    end
+  TwitterConfig = Data.define(:character_limit, :shortened_url_length, :formatting_buffer)
+
+  class TwitterConfig
+    #: () -> Integer
+    def max_content_length = character_limit - shortened_url_length - formatting_buffer
   end
 
   TWITTER_CONFIG = TwitterConfig.new(280, 23, 4) #: TwitterConfig
@@ -67,7 +68,7 @@ class TwitterService < SocialMediaService
 
     # 태그와 링크를 위한 공간 확보 (공백 문자들 포함)
     reserved_space = tags.length + link.length + 3 # " " + "\n" + 여분
-    available_content_length = TWITTER_CONFIG.character_limit - TWITTER_CONFIG.shortened_url_length - TWITTER_CONFIG.formatting_buffer - reserved_space
+    available_content_length = TWITTER_CONFIG.max_content_length - reserved_space
 
     truncated_content = content.truncate([ available_content_length, 1 ].max, omission: "...")
     "#{truncated_content} #{tags}\n#{link}"

--- a/lib/quality/report.rb
+++ b/lib/quality/report.rb
@@ -4,7 +4,8 @@
 
 module Quality
   class Report
-    GateResult = Struct.new(:name, :measure, :threshold, :passed, :unit, :cmp, keyword_init: true)
+    # 멤버 타입: sorbet/rbi/shims/data_definitions.rbi
+    GateResult = Data.define(:name, :measure, :threshold, :passed, :unit, :cmp)
 
     GATES = [
       { name: "Line coverage",       measure_path: [ :coverage, :line ],       threshold_path: [ "coverage", "line_min" ],       cmp: :>=, unit: "%" },

--- a/sorbet/rbi/shims/data_definitions.rbi
+++ b/sorbet/rbi/shims/data_definitions.rbi
@@ -48,6 +48,30 @@ module HumanizeKoreanGoldenChecks
   end
 end
 
+module Quality
+  class Report
+    class GateResult
+      sig { returns(String) }
+      def name; end
+
+      sig { returns(T.nilable(Numeric)) }
+      def measure; end
+
+      sig { returns(T.nilable(Numeric)) }
+      def threshold; end
+
+      sig { returns(T::Boolean) }
+      def passed; end
+
+      sig { returns(String) }
+      def unit; end
+
+      sig { returns(Symbol) }
+      def cmp; end
+    end
+  end
+end
+
 module OauthAccounts
   module Callbacks
     class SignIn


### PR DESCRIPTION
## 무엇을

프로덕션 코드에 남아 있던 `Struct` 정의 3개를 검토해 전부 불변 `Data`로 옮겼다. 세 곳 모두 생성 후 필드를 갱신하지 않는 값 객체라 가변성이 필요 없었다.

| 대상 | 변경 |
|---|---|
| `Quality::Report::GateResult` | `Struct.new(..., keyword_init: true)` → `Data.define`. 호출부는 이미 키워드 생성이라 그대로 |
| `MastodonService::MastodonConfig` | `Struct.new { ... }` → `Data.define` + 클래스 재오픈 |
| `TwitterService::TwitterConfig` | 위와 동일 |

## 왜 블록이 아니라 재오픈인가

`Style/RbsInline/DataDefineWithBlock`이 `Data.define` 블록을 금지하고(RBS::Inline이 블록 내용을 파싱하지 못한다), Sorbet은 `class X < Data.define(...)` 형태를 4002(`Superclasses must only contain constant literals`)로 거부한다. 이미 억제된 4022 덕분에 `app/skills/humanize_korean/scripts/golden/checks.rb`가 쓰는 "상수 할당 + 클래스 재오픈" 관용구가 성립하므로 그 형태에 맞췄다.

덤으로 두 `max_content_length`는 `Struct` 블록 안에서 아무도 부르지 않는 죽은 메서드였고, `build_post_text`가 같은 계산을 손으로 다시 하고 있었다. 호출부가 이 메서드를 쓰도록 바꿔 중복을 없앴다.

## 테스트의 Struct는 왜 그대로인가

`test/` 아래 stub들은 필드 일부만 채우거나 (`Struct.new(:timeout, :open_timeout).new`) 인자 없이 생성한다. `Data`는 모든 멤버가 필수라 그대로 옮길 수 없고, 억지로 맞추면 stub이 검증하려는 대상과 무관한 값을 채워 넣게 된다. 손대지 않았다.

## 검증

- `bundle exec srb tc` — No errors
- `bundle exec rubocop` — 변경 파일 무결
- `bin/rails test` — 979 runs, 0 failures
- `Quality::Report` 렌더링 스모크 확인 (게이트 표 + informational 섹션 정상 출력)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GL51BtBFNo8RexPEmCzDWG