### PR TITLE
fix: federation 해시태그 URL 생성

### DIFF
--- a/app/models/concerns/posts/federation.rb
+++ b/app/models/concerns/posts/federation.rb
@@ -21,7 +21,7 @@ module Posts::Federation
 
     if tag_list.any?
       custom["tag"] = tag_list.map do |name|
-        { "type" => "Hashtag", "name" => "##{name}", "href" => "#{Rails.application.routes.default_url_options[:host]}/tags/#{name}" }
+        { "type" => "Hashtag", "name" => "##{name}", "href" => Rails.application.routes.url_helpers.tag_url(keyword: name) }
       end
     end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,8 +82,10 @@ Rails.application.configure do
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "ruby-news.dev" }
 
-  # Set default URL options for URL helpers
-  Rails.application.routes.default_url_options = { host: "ruby-news.dev" }
+  # Set default URL options for URL helpers. Federation objects (federails.yml
+  # `site_host: https://ruby-news.dev`) and every reader are HTTPS, so URL
+  # generation outside a request context must not fall back to http://.
+  Rails.application.routes.default_url_options = { host: "ruby-news.dev", protocol: "https" }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
   # config.action_mailer.smtp_settings = {

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -567,6 +567,7 @@ class PostTest < ActiveSupport::TestCase
     assert_equal @root_post.federated_url || Rails.application.routes.url_helpers.post_url(@root_post), captured[:custom]["inReplyTo"]
     assert_equal 2, captured[:custom]["tag"].size
     assert_equal "Hashtag", captured[:custom]["tag"].first["type"]
+    assert_equal "http://example.com/tag/ruby", captured[:custom]["tag"].first["href"]
     assert_equal 1, captured[:custom]["attachment"].size
   end
 

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -568,6 +568,7 @@ class PostTest < ActiveSupport::TestCase
     assert_equal 2, captured[:custom]["tag"].size
     assert_equal "Hashtag", captured[:custom]["tag"].first["type"]
     assert_equal "http://example.com/tag/ruby", captured[:custom]["tag"].first["href"]
+    assert_equal "http://example.com/tag/rails", captured[:custom]["tag"].second["href"]
     assert_equal 1, captured[:custom]["attachment"].size
   end
 


### PR DESCRIPTION
## 변경 사항
- ActivityPub 해시태그 `href`를 앱의 `tag_url(keyword:)` 라우트 헬퍼로 생성합니다.
- 스킴이 누락된 URL과 잘못된 복수형 `/tags/` 경로를 해결하는 회귀 테스트를 추가했습니다.

## 원인 및 영향
기존 구현은 host와 경로를 문자열로 조립해 `example.com/tags/ruby`를 만들었습니다. 일부 ActivityPub 소비자가 처리하지 못할 수 있는 스킴 없는 URI이자 실제 `/tag/:keyword` 라우트와 불일치하는 값이었습니다.

## 검증
- `bin/rails test test/models/post_test.rb` — 87 runs, 193 assertions, 0 failures
- `bin/rails 'ai:tool[validate]'` — 대상 파일 2개 통과
- `bin/rubocop app/models/concerns/posts/federation.rb test/models/post_test.rb` — 0 offenses
- `bin/rake quality`는 RuboCop 병렬 실행의 임시 디렉터리 오류로 Gate 1~4 평가 전에 중단되었습니다.

Closes #819