### PR TITLE
refactor(views): articles/show 분해 및 ItemList JSON-LD 추출 (#845)

### DIFF
--- a/app/components/articles/show/comments_section.rb
+++ b/app/components/articles/show/comments_section.rb
@@ -1,0 +1,32 @@
+# typed: true
+# frozen_string_literal: true
+
+# 기사 상세 하단의 댓글 헤더 + 작성 폼 + 목록.
+class Components::Articles::Show::CommentsSection < Components::Base
+  def initialize(article:, comments:, comment:)
+    @article = article
+    @comments = comments
+    @comment = comment
+  end
+
+  def view_template
+    render RubyUI::Card.new(class: "bg-surface overflow-hidden border-border-strong") do
+      render RubyUI::CardContent.new(class: "p-4 md:p-6 lg:p-8") do
+        render RubyUI::Heading.new(
+          level: 2,
+          class: "font-bold text-content mb-6 flex items-center",
+          id: "comments_header"
+        ) { render(Components::Comments::CommentHeader.new(comments: @comments)) }
+
+        render RubyUI::Separator.new(class: "mb-4")
+        div(id: "comment_form") do
+          render(Components::Comments::CommentForm.new(article: @article, comment: @comment))
+        end
+
+        div(class: "space-y-4 pt-6") do
+          render(Components::Comments::Comments.new(article: @article, comments: @comments))
+        end
+      end
+    end
+  end
+end

--- a/app/components/articles/show/header.rb
+++ b/app/components/articles/show/header.rb
@@ -1,0 +1,128 @@
+# typed: true
+# frozen_string_literal: true
+
+# 기사 상세 상단: 히어로 썸네일 + 제목/메타 정보 + 원문 링크.
+class Components::Articles::Show::Header < Components::Base
+  include PhlexIcons
+  include Phlex::Rails::Helpers::ImageTag
+
+  def initialize(presenter:)
+    @presenter = presenter
+    @article = presenter.article
+  end
+
+  def view_template
+    render_hero_thumbnail
+    render_header
+  end
+
+  private
+
+  def render_hero_thumbnail
+    return unless @presenter.hero_thumbnail?
+
+    div(class: "w-full overflow-hidden") do
+      image_tag(
+        cdn_variant_url(@article.thumbnail, :hero),
+        class: "w-full aspect-video object-cover",
+        srcset: "#{cdn_variant_url(@article.thumbnail, :card)} 600w, #{cdn_variant_url(@article.thumbnail, :hero)} 1200w",
+        sizes: "(min-width: 768px) 768px, 100vw",
+        loading: "eager",
+        decoding: "auto",
+        fetchpriority: "high",
+        alt: @article.display_title
+      )
+    end
+  end
+
+  def render_header
+    header(class: "p-4 md:p-6 lg:p-8") do
+      div(class: "mb-6") do
+        render RubyUI::Heading.new(
+          level: 1,
+          class: "text-2xl! lg:text-3xl! font-bold text-content mb-4 leading-tight"
+        ) { @article.display_title }
+
+        p(class: "text-lg font-medium text-content-secondary mb-4 wrap-break-word") { @article.title }
+      end
+
+      render_meta_row
+      render_source_link
+    end
+  end
+
+  def render_meta_row
+    div(class: "flex flex-wrap items-center gap-4 md:gap-6 text-sm text-content-secondary") do
+      render_author
+      render_published_at
+
+      render Components::Likes::Button.new(likeable: @article)
+      render Components::Boosts::Button.new(boostable: @article)
+      render_markdown_copy_button
+    end
+  end
+
+  def render_author
+    div(class: "flex items-center") do
+      div(class: "w-8 h-8 bg-brand-solid rounded-full flex items-center justify-center mr-3") do
+        Hero::User(variant: :outline, class: "w-4 h-4 text-brand-foreground")
+      end
+      div do
+        div(class: "text-xs text-content-secondary") { t("articles.show.author") }
+        div(class: "font-medium text-content") do
+          render(Components::Articles::ArticleUser.new(article: @article))
+        end
+      end
+    end
+  end
+
+  def render_published_at
+    div(class: "flex items-center") do
+      Hero::Calendar(variant: :outline, class: "w-5 h-5 mr-2 text-content-muted")
+      div do
+        div(class: "text-xs text-content-secondary") { t("articles.show.published_at") }
+        div(class: "font-medium text-content") do
+          time(datetime: @presenter.published_at_iso) do
+            plain @presenter.published_at_label(t("articles.show.date_format")) || t("articles.show.not_available")
+          end
+        end
+      end
+    end
+  end
+
+  def render_markdown_copy_button
+    button(
+      type: "button",
+      class: "inline-flex items-center gap-1 text-sm text-content-muted hover:text-brand transition-colors p-0",
+      aria_label: t("articles.show.copy_markdown"),
+      data: {
+        controller: "markdown-copy",
+        markdown_copy_url_value: article_path(@article, format: :md),
+        action: "markdown-copy#copy"
+      }
+    ) do
+      Tabler::Markdown(variant: :outline, class: "w-4 h-4")
+      span(
+        data: { markdown_copy_target: "label", done_label: t("articles.show.copy_markdown_done") }
+      ) { t("articles.show.copy_markdown") }
+    end
+  end
+
+  def render_source_link
+    div(class: "mt-6 p-4 bg-surface-muted rounded-lg") do
+      div(class: "flex items-center min-w-0") do
+        div(class: "w-10 h-10 bg-info-solid rounded-lg flex items-center justify-center mr-3 shrink-0") do
+          Hero::ArrowTopRightOnSquare(variant: :outline, class: "w-5 h-5 text-brand-foreground")
+        end
+        div(class: "min-w-0 flex-1") do
+          a(
+            href: @article.url,
+            target: "_blank",
+            rel: "noopener noreferrer",
+            class: "text-sm font-medium text-info-text hover:text-info-text-hover transition-colors wrap-break-word"
+          ) { @article.url }
+        end
+      end
+    end
+  end
+end

--- a/app/components/articles/show/similar_articles.rb
+++ b/app/components/articles/show/similar_articles.rb
@@ -1,0 +1,52 @@
+# typed: true
+# frozen_string_literal: true
+
+# 기사 상세 하단의 관련 기사 카드 그리드.
+class Components::Articles::Show::SimilarArticles < Components::Base
+  include PhlexIcons
+  include Phlex::Rails::Helpers::LinkTo
+
+  def initialize(articles:)
+    @articles = articles
+  end
+
+  def view_template
+    return if @articles.blank?
+
+    render RubyUI::Card.new(class: "bg-surface overflow-hidden border-border-strong") do
+      render RubyUI::CardContent.new(class: "p-4 md:p-6 lg:p-8") do
+        render RubyUI::Heading.new(level: 2, class: "font-bold text-content mb-6 flex items-center") do
+          Hero::Newspaper(variant: :outline, class: "w-6 h-6 mr-2 text-brand")
+          plain t("articles.show.related_heading")
+        end
+
+        div(class: "grid grid-cols-1 md:grid-cols-2 gap-4 lg:gap-6") do
+          @articles.each { |article| render_card(article) }
+        end
+      end
+    end
+  end
+
+  private
+
+  def render_card(article)
+    div(class: "group bg-surface-muted rounded-lg border border-border-muted hover:border-border-strong hover:shadow-sm transition-all duration-200 overflow-hidden") do
+      link_to(article_path(article), class: "block p-4 lg:p-6") do
+        render RubyUI::Heading.new(
+          level: 3,
+          class: "font-semibold text-content group-hover:text-link-hover transition-colors duration-200 mb-3 line-clamp-2"
+        ) { article.display_title }
+
+        render RubyUI::Badge.new(variant: :blue, size: :sm, class: "mb-3") { article.host }
+
+        p(class: "text-content-secondary text-sm leading-relaxed line-clamp-3 mb-4") do
+          plain article.summary_key_preview.to_s
+        end
+
+        div(class: "flex items-center justify-end text-xs text-content-secondary") do
+          span(class: "group-hover:text-link-hover transition-colors duration-200") { t("articles.show.read_more") }
+        end
+      end
+    end
+  end
+end

--- a/app/components/articles/show/summary.rb
+++ b/app/components/articles/show/summary.rb
@@ -1,0 +1,93 @@
+# typed: true
+# frozen_string_literal: true
+
+# 기사 상세 본문: 핵심 요약 박스 + 서론/본문/결론.
+class Components::Articles::Show::Summary < Components::Base
+  include PhlexIcons
+  include Phlex::Rails::Helpers::Sanitize
+
+  def initialize(presenter:)
+    @presenter = presenter
+  end
+
+  def view_template
+    div(class: "p-4 md:p-6 lg:p-8") do
+      render_summary_key
+      render_summary_detail
+    end
+  end
+
+  private
+
+  def render_summary_key
+    section(class: "mb-8 lg:mb-12") do
+      div(class: "bg-linear-to-r from-brand-solid to-brand-solid-hover rounded-lg p-6") do
+        render RubyUI::Heading.new(
+          level: 2,
+          class: "font-bold text-brand-foreground mb-4 flex items-center"
+        ) do
+          Hero::CheckCircle(variant: :outline, class: "w-6 h-6 mr-2")
+          plain t("articles.show.summary_heading")
+        end
+
+        render_summary_key_items if @presenter.summary_key_items?
+      end
+    end
+  end
+
+  def render_summary_key_items
+    ul(class: "space-y-3") do
+      @presenter.summary_key_items.each_with_index do |item, index|
+        li(class: "flex items-start") do
+          span(class: "shrink-0 w-5 text-brand-foreground/60 font-semibold text-sm tabular-nums mt-0.5 mr-2 text-right") do
+            plain "#{index + 1}."
+          end
+          span(class: "text-brand-foreground leading-relaxed") { plain item }
+        end
+      end
+    end
+  end
+
+  def render_summary_detail
+    section(class: "prose dark:prose-invert prose-lg max-w-none prose-headings:text-prose-heading-accent prose-strong:text-prose-strong-accent") do
+      render_introduction
+      render_body
+      render_conclusion
+    end
+  end
+
+  def render_introduction
+    introduction = @presenter.introduction
+    return if introduction.blank?
+
+    div(class: "mb-8 p-6 bg-surface-muted rounded-xl border-l-4 border-state-info") do
+      render RubyUI::Heading.new(level: 3, class: "font-semibold text-info-text mb-3") { t("articles.show.intro_heading") }
+      div(class: "text-content-secondary leading-relaxed text-base") do
+        plain introduction
+      end
+    end
+  end
+
+  def render_body
+    body_markdown = @presenter.summary_body
+    return if body_markdown.blank?
+
+    div(class: "mb-8 article-content", id: "article-detail-body") do
+      div(class: "prose dark:prose-invert max-w-none prose-headings:text-prose-heading-accent prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg prose-h4:text-base prose-strong:text-prose-strong-accent text-content-secondary leading-loose") do
+        raw sanitize(Inkmark.to_html(body_markdown, options: { preset: :trusted }))
+      end
+    end
+  end
+
+  def render_conclusion
+    conclusion = @presenter.conclusion
+    return if conclusion.blank?
+
+    div(class: "p-6 bg-surface-muted rounded-xl border-l-4 border-brand") do
+      render RubyUI::Heading.new(level: 3, class: "font-semibold text-accent-text mb-3") { t("articles.show.conclusion_heading") }
+      div(class: "text-content-secondary leading-relaxed text-base") do
+        plain conclusion
+      end
+    end
+  end
+end

--- a/app/components/structured_data/item_list.rb
+++ b/app/components/structured_data/item_list.rb
@@ -1,0 +1,29 @@
+# typed: true
+# frozen_string_literal: true
+
+# 기사 목록 페이지의 ItemList JSON-LD 를 렌더한다.
+# payload 구성은 Articles::ItemListSchema 가 담당한다.
+class Components::StructuredData::ItemList < Components::Base
+  def initialize(name:, articles:)
+    @name = name
+    @articles = articles
+  end
+
+  def view_template
+    return if @articles.blank?
+
+    script(type: "application/ld+json") do
+      raw(json_ld.html_safe)
+    end
+  end
+
+  private
+
+  def json_ld
+    # Components::Articles 네임스페이스가 있어 상대 경로로 쓰면 그쪽으로 잡힌다.
+    ::Articles::ItemListSchema.json(
+      name: @name,
+      urls: @articles.map { |article| article_url(article) }
+    )
+  end
+end

--- a/app/functions/articles/item_list_schema.rb
+++ b/app/functions/articles/item_list_schema.rb
@@ -1,0 +1,38 @@
+# typed: true
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+module Articles
+  # 기사 목록 페이지(home/index, articles/index·tagged·others)가 공유하는
+  # schema.org ItemList payload 빌더. 뷰는 렌더만 담당하고 payload 구성은
+  # 여기서 한다.
+  module ItemListSchema
+    SCHEMA_CONTEXT = "https://schema.org"
+    DESCENDING_ORDER = "https://schema.org/ItemListOrderDescending"
+
+    class << self
+      #: (name: String, urls: Array[String]) -> Hash[String, untyped]
+      def payload(name:, urls:)
+        {
+          "@context" => SCHEMA_CONTEXT,
+          "@type" => "ItemList",
+          "name" => name,
+          "itemListOrder" => DESCENDING_ORDER,
+          "numberOfItems" => urls.size,
+          "itemListElement" => urls.each_with_index.map do |url, index|
+            {
+              "@type" => "ListItem",
+              "position" => index + 1,
+              "url" => url
+            }
+          end
+        }
+      end
+
+      #: (name: String, urls: Array[String]) -> String
+      def json(name:, urls:)
+        JSON.generate(payload(name: name, urls: urls))
+      end
+    end
+  end
+end

--- a/app/presenters/article_show_presenter.rb
+++ b/app/presenters/article_show_presenter.rb
@@ -1,0 +1,74 @@
+# typed: true
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# 기사 상세(show) 화면의 표시 판단을 모아둔다.
+# display_summary_* 는 로케일 폴백에 따라 Hash/Array/nil 이 섞여 들어오므로,
+# 뷰가 타입 분기를 하지 않도록 여기서 정규화한다.
+class ArticleShowPresenter
+  #: (Article article) -> void
+  def initialize(article)
+    @article = article
+  end
+
+  attr_reader :article
+
+  #: () -> bool
+  def hero_thumbnail?
+    article.thumbnail.attached?
+  end
+
+  # 요약 핵심 항목. Array 가 아니면 렌더하지 않는다.
+  #: () -> Array[untyped]
+  def summary_key_items
+    items = article.display_summary_key
+    items.is_a?(Array) ? items : []
+  end
+
+  #: () -> bool
+  def summary_key_items?
+    summary_key_items.any?
+  end
+
+  # 상세 요약은 Hash 일 때만 본문/서론/결론을 렌더한다.
+  #: () -> bool
+  def summary_detail?
+    article.display_summary_detail.is_a?(Hash)
+  end
+
+  #: () -> String?
+  def introduction
+    summary_detail_value("introduction")
+  end
+
+  #: () -> String?
+  def conclusion
+    summary_detail_value("conclusion")
+  end
+
+  #: () -> String?
+  def summary_body
+    return nil unless summary_detail?
+
+    article.display_summary_body.presence
+  end
+
+  #: () -> String?
+  def published_at_iso
+    article.published_at&.iso8601
+  end
+
+  #: (String format) -> String?
+  def published_at_label(format)
+    article.published_at&.strftime(format)
+  end
+
+  private
+
+  #: (String key) -> String?
+  def summary_detail_value(key)
+    return nil unless summary_detail?
+
+    article.display_summary_detail[key].presence
+  end
+end

--- a/app/views/articles/index.rb
+++ b/app/views/articles/index.rb
@@ -84,25 +84,9 @@ class Views::Articles::Index < Views::Base
   end
 
   def render_item_list_schema
-    return if @articles.empty?
-
-    payload = {
-      "@context" => "https://schema.org",
-      "@type" => "ItemList",
-      "name" => t("articles.index.item_list_name"),
-      "itemListOrder" => "https://schema.org/ItemListOrderDescending",
-      "numberOfItems" => @articles.size,
-      "itemListElement" => @articles.each_with_index.map do |article, idx|
-        {
-          "@type" => "ListItem",
-          "position" => idx + 1,
-          "url" => article_url(article)
-        }
-      end
-    }
-
-    script(type: "application/ld+json") do
-      raw(JSON.generate(payload).html_safe)
-    end
+    render Components::StructuredData::ItemList.new(
+      name: t("articles.index.item_list_name"),
+      articles: @articles
+    )
   end
 end

--- a/app/views/articles/others.rb
+++ b/app/views/articles/others.rb
@@ -50,25 +50,9 @@ class Views::Articles::Others < Views::Base
   private
 
   def render_item_list_schema
-    return if @articles.empty?
-
-    payload = {
-      "@context" => "https://schema.org",
-      "@type" => "ItemList",
-      "name" => t("articles.others.item_list_name"),
-      "itemListOrder" => "https://schema.org/ItemListOrderDescending",
-      "numberOfItems" => @articles.size,
-      "itemListElement" => @articles.each_with_index.map do |article, idx|
-        {
-          "@type" => "ListItem",
-          "position" => idx + 1,
-          "url" => article_url(article)
-        }
-      end
-    }
-
-    script(type: "application/ld+json") do
-      raw(JSON.generate(payload).html_safe)
-    end
+    render Components::StructuredData::ItemList.new(
+      name: t("articles.others.item_list_name"),
+      articles: @articles
+    )
   end
 end

--- a/app/views/articles/show.rb
+++ b/app/views/articles/show.rb
@@ -2,263 +2,43 @@
 # frozen_string_literal: true
 
 class Views::Articles::Show < Views::Base
-  include PhlexIcons
   include Phlex::Rails::Helpers::ContentFor
   include Phlex::Rails::Helpers::DOMID
-  include Phlex::Rails::Helpers::LinkTo
-  include Phlex::Rails::Helpers::ImageTag
-  include Phlex::Rails::Helpers::Sanitize
 
   def initialize(article:, comments:, comment:, similar_articles:)
     @article = article
     @comments = comments
     @comment = comment
     @similar_articles = similar_articles
+    @presenter = ArticleShowPresenter.new(article)
   end
 
   def view_template
     content_for(:title, @article.display_title)
 
     # NewsArticle + breadcrumbs JSON-LD are rendered into <head> by
-    # Components::Layout#render_schema_org, which reads @news_article / @breadcrumbs
+    # Components::Layout::StructuredData, which reads @news_article / @breadcrumbs
     # (set in ArticlesController#show) from view_context. They are NOT available as
     # Phlex view ivars here, so do not reference them in this template.
 
     div(class: "space-y-6 lg:space-y-8 max-w-6xl mx-auto", id: dom_id(@article)) do
       render_article_main
-      render_similar_articles if @similar_articles.present?
-      render_comments_section
+      render Components::Articles::Show::SimilarArticles.new(articles: @similar_articles)
+      render Components::Articles::Show::CommentsSection.new(
+        article: @article,
+        comments: @comments,
+        comment: @comment
+      )
     end
   end
 
   private
 
-  # Shift markdown headings so that # and ## become ### (minimum h3)
-  def downshift_headings(markdown)
-    markdown.gsub(/^(#+)\s/) do
-      # Group 1 always participates in this pattern, so the fallback is
-      # unreachable. It is 1 rather than 0 so that if it ever does fire the
-      # result is still the h3 this method promises, not an h2.
-      level = Regexp.last_match(1)&.length || 1
-      new_level = [ level + 2, 6 ].min
-      "#" * new_level + " "
-    end
-  end
-
   def render_article_main
     article(class: "bg-surface rounded-xl overflow-hidden border border-border-strong") do
-      render_hero_thumbnail
-      render_article_header
+      render Components::Articles::Show::Header.new(presenter: @presenter)
       render RubyUI::Separator.new
-      render_article_body
-    end
-  end
-
-  def render_hero_thumbnail
-    return unless @article.thumbnail.attached?
-
-    div(class: "w-full overflow-hidden") do
-      image_tag(
-        cdn_variant_url(@article.thumbnail, :hero),
-        class: "w-full aspect-video object-cover",
-        srcset: "#{cdn_variant_url(@article.thumbnail, :card)} 600w, #{cdn_variant_url(@article.thumbnail, :hero)} 1200w",
-        sizes: "(min-width: 768px) 768px, 100vw",
-        loading: "eager",
-        decoding: "auto",
-        fetchpriority: "high",
-        alt: @article.display_title
-      )
-    end
-  end
-
-  def render_article_header
-    header(class: "p-4 md:p-6 lg:p-8") do
-      div(class: "mb-6") do
-        render RubyUI::Heading.new(
-          level: 1,
-          class: "text-2xl! lg:text-3xl! font-bold text-content mb-4 leading-tight"
-        ) { @article.display_title }
-
-        p(class: "text-lg font-medium text-content-secondary mb-4 wrap-break-word") { @article.title }
-      end
-
-      div(class: "flex flex-wrap items-center gap-4 md:gap-6 text-sm text-content-secondary") do
-        div(class: "flex items-center") do
-          div(class: "w-8 h-8 bg-brand-solid rounded-full flex items-center justify-center mr-3") do
-            Hero::User(variant: :outline, class: "w-4 h-4 text-brand-foreground")
-          end
-          div do
-            div(class: "text-xs text-content-secondary") { t("articles.show.author") }
-            div(class: "font-medium text-content") do
-              render(Components::Articles::ArticleUser.new(article: @article))
-            end
-          end
-        end
-
-        div(class: "flex items-center") do
-          Hero::Calendar(variant: :outline, class: "w-5 h-5 mr-2 text-content-muted")
-          div do
-            div(class: "text-xs text-content-secondary") { t("articles.show.published_at") }
-            div(class: "font-medium text-content") do
-              time(datetime: @article.published_at&.iso8601) do
-                plain @article.published_at&.strftime(t("articles.show.date_format")) || t("articles.show.not_available")
-              end
-            end
-          end
-        end
-
-        render Components::Likes::Button.new(likeable: @article)
-        render Components::Boosts::Button.new(boostable: @article)
-        render_markdown_copy_button
-      end
-
-      div(class: "mt-6 p-4 bg-surface-muted rounded-lg") do
-        div(class: "flex items-center min-w-0") do
-          div(class: "w-10 h-10 bg-info-solid rounded-lg flex items-center justify-center mr-3 shrink-0") do
-            Hero::ArrowTopRightOnSquare(variant: :outline, class: "w-5 h-5 text-brand-foreground")
-          end
-          div(class: "min-w-0 flex-1") do
-            a(
-              href: @article.url,
-              target: "_blank",
-              rel: "noopener noreferrer",
-              class: "text-sm font-medium text-info-text hover:text-info-text-hover transition-colors wrap-break-word"
-            ) { @article.url }
-          end
-        end
-      end
-    end
-  end
-
-  def render_markdown_copy_button
-    button(
-      type: "button",
-      class: "inline-flex items-center gap-1 text-sm text-content-muted hover:text-brand transition-colors p-0",
-      aria_label: t("articles.show.copy_markdown"),
-      data: {
-        controller: "markdown-copy",
-        markdown_copy_url_value: article_path(@article, format: :md),
-        action: "markdown-copy#copy"
-      }
-    ) do
-      Tabler::Markdown(variant: :outline, class: "w-4 h-4")
-      span(
-        data: { markdown_copy_target: "label", done_label: t("articles.show.copy_markdown_done") }
-      ) { t("articles.show.copy_markdown") }
-    end
-  end
-
-  def render_article_body
-    div(class: "p-4 md:p-6 lg:p-8") do
-      section(class: "mb-8 lg:mb-12") do
-        div(class: "bg-linear-to-r from-brand-solid to-brand-solid-hover rounded-lg p-6") do
-          render RubyUI::Heading.new(
-            level: 2,
-            class: "font-bold text-brand-foreground mb-4 flex items-center"
-          ) do
-            Hero::CheckCircle(variant: :outline, class: "w-6 h-6 mr-2")
-            plain t("articles.show.summary_heading")
-          end
-
-          if @article.display_summary_key.is_a?(Array)
-            ul(class: "space-y-3") do
-              @article.display_summary_key&.each_with_index do |item, index|
-                li(class: "flex items-start") do
-                  span(class: "shrink-0 w-5 text-brand-foreground/60 font-semibold text-sm tabular-nums mt-0.5 mr-2 text-right") do
-                    plain "#{index + 1}."
-                  end
-                  span(class: "text-brand-foreground leading-relaxed") { plain item }
-                end
-              end
-            end
-          end
-        end
-      end
-
-      section(class: "prose dark:prose-invert prose-lg max-w-none prose-headings:text-prose-heading-accent prose-strong:text-prose-strong-accent") do
-        if @article.display_summary_detail.is_a?(Hash)
-          if @article.display_summary_detail["introduction"].present?
-            div(class: "mb-8 p-6 bg-surface-muted rounded-xl border-l-4 border-state-info") do
-              render RubyUI::Heading.new(level: 3, class: "font-semibold text-info-text mb-3") { t("articles.show.intro_heading") }
-              div(class: "text-content-secondary leading-relaxed text-base") do
-                plain @article.display_summary_detail["introduction"]
-              end
-            end
-          end
-
-          if @article.display_summary_body.present?
-            div(class: "mb-8 article-content", id: "article-detail-body") do
-              div(class: "prose dark:prose-invert max-w-none prose-headings:text-prose-heading-accent prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg prose-h4:text-base prose-strong:text-prose-strong-accent text-content-secondary leading-loose") do
-                raw sanitize(Inkmark.to_html(@article.display_summary_body, options: { preset: :trusted }))
-              end
-            end
-          end
-
-          if @article.display_summary_detail["conclusion"].present?
-            div(class: "p-6 bg-surface-muted rounded-xl border-l-4 border-brand") do
-              render RubyUI::Heading.new(level: 3, class: "font-semibold text-accent-text mb-3") { t("articles.show.conclusion_heading") }
-              div(class: "text-content-secondary leading-relaxed text-base") do
-                plain @article.display_summary_detail["conclusion"]
-              end
-            end
-          end
-        end
-      end
-    end
-  end
-
-  def render_similar_articles
-    render RubyUI::Card.new(class: "bg-surface overflow-hidden border-border-strong") do
-      render RubyUI::CardContent.new(class: "p-4 md:p-6 lg:p-8") do
-        render RubyUI::Heading.new(level: 2, class: "font-bold text-content mb-6 flex items-center") do
-          Hero::Newspaper(variant: :outline, class: "w-6 h-6 mr-2 text-brand")
-          plain t("articles.show.related_heading")
-        end
-
-        div(class: "grid grid-cols-1 md:grid-cols-2 gap-4 lg:gap-6") do
-          @similar_articles.each do |article|
-            div(class: "group bg-surface-muted rounded-lg border border-border-muted hover:border-border-strong hover:shadow-sm transition-all duration-200 overflow-hidden") do
-              link_to(article_path(article), class: "block p-4 lg:p-6") do
-                render RubyUI::Heading.new(
-                  level: 3,
-                  class: "font-semibold text-content group-hover:text-link-hover transition-colors duration-200 mb-3 line-clamp-2"
-                ) { article.display_title }
-
-                render RubyUI::Badge.new(variant: :blue, size: :sm, class: "mb-3") { article.host }
-
-                p(class: "text-content-secondary text-sm leading-relaxed line-clamp-3 mb-4") do
-                  plain article.summary_key_preview.to_s
-                end
-
-                div(class: "flex items-center justify-end text-xs text-content-secondary") do
-                  span(class: "group-hover:text-link-hover transition-colors duration-200") { t("articles.show.read_more") }
-                end
-              end
-            end
-          end
-        end
-      end
-    end
-  end
-
-  def render_comments_section
-    render RubyUI::Card.new(class: "bg-surface overflow-hidden border-border-strong") do
-      render RubyUI::CardContent.new(class: "p-4 md:p-6 lg:p-8") do
-        render RubyUI::Heading.new(
-          level: 2,
-          class: "font-bold text-content mb-6 flex items-center",
-          id: "comments_header"
-        ) { render(Components::Comments::CommentHeader.new(comments: @comments)) }
-
-        render RubyUI::Separator.new(class: "mb-4")
-        div(id: "comment_form") do
-          render(Components::Comments::CommentForm.new(article: @article, comment: @comment))
-        end
-
-        div(class: "space-y-4 pt-6") do
-          render(Components::Comments::Comments.new(article: @article, comments: @comments))
-        end
-      end
+      render Components::Articles::Show::Summary.new(presenter: @presenter)
     end
   end
 end

--- a/app/views/articles/tagged.rb
+++ b/app/views/articles/tagged.rb
@@ -49,25 +49,9 @@ class Views::Articles::Tagged < Views::Base
   private
 
   def render_item_list_schema
-    return if @articles.empty?
-
-    payload = {
-      "@context" => "https://schema.org",
-      "@type" => "ItemList",
-      "name" => t("articles.tagged.item_list_name", tag: @tag),
-      "itemListOrder" => "https://schema.org/ItemListOrderDescending",
-      "numberOfItems" => @articles.size,
-      "itemListElement" => @articles.each_with_index.map do |article, idx|
-        {
-          "@type" => "ListItem",
-          "position" => idx + 1,
-          "url" => article_url(article)
-        }
-      end
-    }
-
-    script(type: "application/ld+json") do
-      raw(JSON.generate(payload).html_safe)
-    end
+    render Components::StructuredData::ItemList.new(
+      name: t("articles.tagged.item_list_name", tag: @tag),
+      articles: @articles
+    )
   end
 end

--- a/app/views/home/index.rb
+++ b/app/views/home/index.rb
@@ -74,26 +74,9 @@ class Views::Home::Index < Views::Base
   private
 
   def render_item_list_schema
-    items = (@featured_articles + @articles)
-    return if items.empty?
-
-    payload = {
-      "@context" => "https://schema.org",
-      "@type" => "ItemList",
-      "name" => t("home.index.item_list_name"),
-      "itemListOrder" => "https://schema.org/ItemListOrderDescending",
-      "numberOfItems" => items.size,
-      "itemListElement" => items.each_with_index.map do |article, idx|
-        {
-          "@type" => "ListItem",
-          "position" => idx + 1,
-          "url" => article_url(article)
-        }
-      end
-    }
-
-    script(type: "application/ld+json") do
-      raw(JSON.generate(payload).html_safe)
-    end
+    render Components::StructuredData::ItemList.new(
+      name: t("home.index.item_list_name"),
+      articles: @featured_articles + @articles
+    )
   end
 end

--- a/spec/functions/articles/item_list_schema_spec.rb
+++ b/spec/functions/articles/item_list_schema_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Articles::ItemListSchema do
+  let(:urls) { %w[https://ruby-news.dev/articles/a https://ruby-news.dev/articles/b] }
+
+  describe ".payload" do
+    subject(:payload) { described_class.payload(name: "최신 기사", urls: urls) }
+
+    it "ItemList 스키마 헤더를 구성한다" do
+      expect(payload).to include(
+        "@context" => "https://schema.org",
+        "@type" => "ItemList",
+        "name" => "최신 기사",
+        "itemListOrder" => "https://schema.org/ItemListOrderDescending",
+        "numberOfItems" => 2
+      )
+    end
+
+    it "URL 순서대로 1부터 position 을 매긴다" do
+      expect(payload["itemListElement"]).to eq(
+        [
+          { "@type" => "ListItem", "position" => 1, "url" => urls.first },
+          { "@type" => "ListItem", "position" => 2, "url" => urls.second }
+        ]
+      )
+    end
+
+    it "URL 이 없으면 빈 목록을 반환한다" do
+      empty = described_class.payload(name: "최신 기사", urls: [])
+
+      expect(empty["numberOfItems"]).to eq(0)
+      expect(empty["itemListElement"]).to be_empty
+    end
+  end
+
+  describe ".json" do
+    it "payload 를 JSON 문자열로 직렬화한다" do
+      json = described_class.json(name: "최신 기사", urls: urls)
+
+      expect(JSON.parse(json)).to eq(described_class.payload(name: "최신 기사", urls: urls))
+    end
+  end
+end


### PR DESCRIPTION
Closes #845

## VIEW-01 — `articles/show.rb` 복잡도 분해 (Medium)

264줄 → **41줄**. 표시 분기·구조화 데이터·요약 렌더가 뒤섞여 있던 뷰를 하위 컴포넌트로 나누고, 표시 판단은 presenter로 옮겼다.

- `ArticleShowPresenter` (신규) — `display_summary_*` 가 로케일 폴백에 따라 Hash/Array/nil 로 섞여 들어오는 타입 분기, 썸네일 첨부 여부, 발행일 포맷팅을 흡수한다. 뷰에서 `is_a?(Hash)` / `is_a?(Array)` 가 사라진다.
- `Components::Articles::Show::Header` — 히어로 썸네일 + 제목/작성자/발행일 + 좋아요·부스트·마크다운 복사 + 원문 링크
- `Components::Articles::Show::Summary` — 핵심 요약 박스 + 서론/본문/결론
- `Components::Articles::Show::SimilarArticles` — 관련 기사 그리드 (빈 목록 가드를 컴포넌트 내부로 이동)
- `Components::Articles::Show::CommentsSection` — 댓글 헤더/폼/목록
- 호출처가 없던 `downshift_headings` 와 더 이상 쓰이지 않는 헬퍼 include 제거

## VIEW-02 — 인라인 JSON-LD 추출 (Low)

`home/index`, `articles/{index,tagged,others}` 네 곳에 동일하게 복제돼 있던 payload 구성(각 ~22줄)을 제거했다.

- `Articles::ItemListSchema` (PORO) — `payload(name:, urls:)` / `json(name:, urls:)`
- `Components::StructuredData::ItemList` — `<script type="application/ld+json">` 렌더만 담당
- 각 뷰는 `render Components::StructuredData::ItemList.new(name:, articles:)` 한 줄로 축소

출력 JSON은 기존과 동일하다 (`@context` / `@type` / `name` / `itemListOrder` / `numberOfItems` / `itemListElement`).

⚠️ 상수 해석 주의: `Components::Articles` 네임스페이스가 있어 컴포넌트 안에서 `Articles::ItemListSchema` 를 쓰면 `Components::Articles::ItemListSchema` 로 잡힌다(테스트에서 NameError 로 검출). 루트 스코프 `::Articles::ItemListSchema` 로 고정하고 주석을 남겼다.

## VIEW-03 — layout.rb 인라인 preload (Low)

**이 PR에 변경 없음.** 이슈가 지목한 `app/components/layout.rb:209-224` 는 현재 존재하지 않는다(파일이 120줄). 해당 마크업은 이미 `Components::Layout::AssetPreloads` 로 분리돼 `section:` 인자로 렌더되고 있고 `CGI.escapeHTML` 이스케이프도 유지된다 — 이슈 권고("현행 유지 가능")를 이미 충족한 상태다.

## 검증

- `bin/rails test` — 993 runs, 3125 assertions, 0 failures, 0 errors
- `bundle exec rspec` — 63 examples, 0 failures (신규 `item_list_schema_spec` 4건 포함)
- `bin/rails zeitwerk:check` — All is good
- `bundle exec srb tc` — No errors
- `bundle exec rubocop` (변경 파일) — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 기사 상세 페이지에 썸네일, 제목, 메타 정보, 작성자, 게시일 및 좋아요·부스트 기능을 표시합니다.
  * 기사 요약, 본문, 결론과 댓글 작성·목록 영역을 카드 형태로 제공합니다.
  * 관련 기사를 반응형 카드 그리드로 표시합니다.
  * 기사 목록 페이지의 검색엔진용 구조화 데이터를 개선했습니다.

* **개선 사항**
  * 기사 이미지 로딩과 반응형 표시를 최적화했습니다.
  * 기사 상세 화면의 콘텐츠 구성을 일관된 방식으로 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->